### PR TITLE
Surround status with parentheses in search results

### DIFF
--- a/app/models/full_text_search/searcher_record.rb
+++ b/app/models/full_text_search/searcher_record.rb
@@ -355,11 +355,11 @@ module FullTextSearch
         "#{l(:label_document)}: "
       when "Issue"
         issue = original_record
-        "#{issue.tracker.name} ##{original_id} #{issue.status}: "
+        "#{issue.tracker.name} ##{original_id} (#{issue.status}): "
       when "Journal"
         journal = original_record
         issue = journal.issue
-        "#{issue.tracker.name} ##{issue.id}#{issue.status}: "
+        "#{issue.tracker.name} ##{issue.id} (#{issue.status}): "
       when "Message"
         "#{original_record.board.name}: "
       when "Project"


### PR DESCRIPTION
This is like Redmine default search.

### Before fix

![before-fix](https://user-images.githubusercontent.com/238681/34779906-f8defa7a-f664-11e7-8900-1ba104c50b9d.png)

### After fix

![after-fix](https://user-images.githubusercontent.com/238681/34779917-015b56e4-f665-11e7-8c36-01dba4ee53a8.png)

### Redmine default search

![redmine-default](https://user-images.githubusercontent.com/238681/34779945-1134b47a-f665-11e7-9dfa-b08ed39446d3.png)
