### PR TITLE
Change from include to prepend for additional helper method.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -31,5 +31,4 @@ Rails.configuration.to_prepare do
   Journal.include(FullTextSearch::SimilarSearcher::Model)
   SearchHelper.prepend(FullTextSearch::Hooks::SearchHelper)
   SearchController.prepend(FullTextSearch::Hooks::ControllerSearchIndex)
-  IssuesHelper.include(FullTextSearch::Hooks::SimilarIssuesHelper)
 end

--- a/lib/full_text_search/hooks/similar_issues_helper.rb
+++ b/lib/full_text_search/hooks/similar_issues_helper.rb
@@ -22,3 +22,4 @@ module FullTextSearch
     end
   end
 end
+IssuesHelper.prepend(FullTextSearch::Hooks::SimilarIssuesHelper)


### PR DESCRIPTION
Workaround for clear-code/redmine_full_text_search#55

I'm not sure this workaround is best or not, but I could fix above and related issues.

### Step to repoduce

Also I attached simple plugin to reproduce method missing error in case using both plugin.

- [aaaaa.zip](https://github.com/clear-code/redmine_full_text_search/files/2338626/aaaaa.zip)

When using rails console, you could confim IssuesController.helpers.

Here is simple confirmation to call method.
In case patch not applied, the method is missing.

```
irb(main):001:0> IssuesController.helpers.display_score?
NoMethodError: undefined method `display_score?' for #<ActionView::Base:0x00000004adb7c8>
Did you mean?  display_main_menu?

```

After patch is applied, enabled to call the method.

```
irb(main):001:0> IssuesController.helpers.display_score?
  Setting Load (0.8ms)  SELECT  "settings".* FROM "settings" WHERE "settings"."name" = $1  ORDER BY "settings"."id" DESC LIMIT 1  [["name", "plugin_full_text_search"]]
=> true
```


### Another workaround

Another workaround to prevent this error is following:

```
--- a/app/views/issues/full_text_search/_view_issues_show_description_bottom.html.erb
+++ b/app/views/issues/full_text_search/_view_issues_show_description_bottom.html.erb
@@ -1,3 +1,4 @@
+<% self.class.send(:include, FullTextSearch::Hooks::SimilarIssuesHelper) -%>
 <% if display_score? %>
   <%
   duration = nil

```
Include module to AcrtionView::Base class.

Since this plugin is quite useful, I really appreciate if you could consider to fix this problem.


