### PR TITLE
Fixes broken links on result of searching forums.

### DIFF
--- a/app/models/full_text_search/searcher_record.rb
+++ b/app/models/full_text_search/searcher_record.rb
@@ -341,6 +341,8 @@ module FullTextSearch
         { controller: "issues", action: "show", id: journal.issue.id, anchor: "change-#{original_id}" }
       when "News", "news"
         { controller: "news", action: "show", id: original_id }
+      when "Message", "message"
+        { controller: "messages", action: "show", board_id: original_record.board.id, id: original_id }
       when "Project", "project"
         { controller: "projects", action: "show", id: original_id }
       when "WikiPage", "wikipage"


### PR DESCRIPTION
After this plugin installed, links on result of searching forums are broken.
That links jump to welcome page, but should jump to some topics.

in Japanese, 
フォーラムを検索した場合に、検索結果のリンクが正しく行われていません。
すべてウエルカムページに飛ばされてしまいます。
パッチを書きましたので、よろしくお願いします。