### PR TITLE
Fixes a problem to show results on other projects with searching custom fields

### DIFF
--- a/app/models/full_text_search/searcher_record.rb
+++ b/app/models/full_text_search/searcher_record.rb
@@ -81,6 +81,7 @@ module FullTextSearch
                         else
                           Project.visible(user).pluck(:id)
                         end
+          return [] if project_ids.empty?
         end
 
         unless attachments == "only"

--- a/lib/full_text_search/mroonga.rb
+++ b/lib/full_text_search/mroonga.rb
@@ -60,7 +60,7 @@ module FullTextSearch
       def filter_condition(user, project_ids, scope, attachments, open_issues)
         conditions = _filter_condition(user, project_ids, scope, attachments, open_issues)
         if conditions.empty?
-          "1==1"
+          "1==0"
         else
           build_condition("||", conditions)
         end


### PR DESCRIPTION
When I search a text on custom fields in specified project, a result has other project issues.
I fix and request patch.

**How to reproduce**
1. Create 2 projects. ex. Project A and Project B.
2. Create a custom field for issue. ex. cf1 which are text type field and searchable.
3. Create issues each projects. The issues have same values in custom fields.  
     ex. Project A  cf1's value is **cf1 Project A**
           Project B  cf1's value is **cf1 Project B**
4. Select **Project A** and search **cf1**.
    Expectation is showing result only Project A's issue, but you also see Project B's issue.

In Japanese,
プロジェクトを選択した状態で検索を行った際、カスタムフィールドに該当文字列があると、別のプロジェクトの結果まで表示されています。
パッチを書きましたので、よろしくお願いします。
