### PR TITLE
Add an option whether include `search_id` and `search_n` in URL.

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -169,14 +169,9 @@
       <% @result_set.each_with_index do |e, i| %>
         <dt class="<%= e.event_type %> icon icon-<%= e.event_type %>">
           <%= content_tag("span", e.project, :class => "project") unless @project == e.project %>
-          <% if fts_add_search_related_parameters_in_url? %>
           <%= link_to(e.event_highlighted_title,
-                      e.event_url.merge("search_id" => @search_request.search_id,
-                                        "search_n" => i + @search_request.offset),
+                      search_result_entry_url(e, i),
                       :data => {:rank => e.rank}) %>
-          <% else %>
-          <%= link_to(e.event_highlighted_title, :data => {:rank => e.rank}) %>
-          <% end %>
         </dt>
         <dd>
           <ol class="search-snippets">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -169,10 +169,14 @@
       <% @result_set.each_with_index do |e, i| %>
         <dt class="<%= e.event_type %> icon icon-<%= e.event_type %>">
           <%= content_tag("span", e.project, :class => "project") unless @project == e.project %>
+          <% if fts_add_search_related_parameters_in_url? %>
           <%= link_to(e.event_highlighted_title,
                       e.event_url.merge("search_id" => @search_request.search_id,
                                         "search_n" => i + @search_request.offset),
                       :data => {:rank => e.rank}) %>
+          <% else %>
+          <%= link_to(e.event_highlighted_title, :data => {:rank => e.rank}) %>
+          <% end %>
         </dt>
         <dd>
           <ol class="search-snippets">

--- a/app/views/settings/_full_text_search.html.erb
+++ b/app/views/settings/_full_text_search.html.erb
@@ -15,11 +15,11 @@
 </p>
 
 <p>
-  <%= label_tag("settings[add_search_related_parameters_in_url]",
-                l(:label_full_text_search_add_search_related_parameters_in_url)) %>
-  <%= check_box_tag("settings[add_search_related_parameters_in_url]",
+  <%= label_tag("settings[enable_tracking]",
+                l(:label_full_text_search_enable_tracking)) %>
+  <%= check_box_tag("settings[enable_tracking]",
                     FullTextSearch::Settings::TRUE_VALUE,
-                    settings.add_search_related_parameters_in_url?) %>
+                    settings.enable_tracking?) %>
 </p>
 
 <p>

--- a/app/views/settings/_full_text_search.html.erb
+++ b/app/views/settings/_full_text_search.html.erb
@@ -15,6 +15,14 @@
 </p>
 
 <p>
+  <%= label_tag("settings[add_search_related_parameters_in_url]",
+                l(:label_full_text_search_add_search_related_parameters_in_url)) %>
+  <%= check_box_tag("settings[add_search_related_parameters_in_url]",
+                    FullTextSearch::Settings::TRUE_VALUE,
+                    settings.add_search_related_parameters_in_url?) %>
+</p>
+
+<p>
   <%= label_tag("settings[attachment_max_text_size_in_mb]",
                 l(:label_full_text_search_attachment_max_text_size)) %>
   <%= text_field_tag("settings[attachment_max_text_size_in_mb]",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
   label_full_text_search_text_extraction_timeout: Timeout in seconds for text extraction
   label_full_text_search_external_command_max_memory: Max memory usage for executing an external command
   label_full_text_search_server_url: ChupaText server URL
-  label_full_text_search_add_search_related_parameters_in_url: Add search_id and search_n into url parameters
+  label_full_text_search_enable_tracking: Enable tracking
   label_similar_issues: Similar issues
   label_extension: Extension
   label_text_extraction: Text extraction

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   label_full_text_search_text_extraction_timeout: Timeout in seconds for text extraction
   label_full_text_search_external_command_max_memory: Max memory usage for executing an external command
   label_full_text_search_server_url: ChupaText server URL
+  label_full_text_search_add_search_related_parameters_in_url: Add search_id and search_n into url parameters
   label_similar_issues: Similar issues
   label_extension: Extension
   label_text_extraction: Text extraction

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
   label_full_text_search_text_extraction_timeout: テキスト抽出処理のタイムアウト時間（秒）
   label_full_text_search_external_command_max_memory: 外部コマンドの最大使用可能メモリー
   label_full_text_search_server_url: ChupaTextサーバーのURL
+  label_full_text_search_add_search_related_parameters_in_url: search_idとsearch_nをURLパラメータに追加
   label_similar_issues: 類似チケット
   label_extension: 拡張子
   label_text_extraction: テキスト抽出

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,7 @@ ja:
   label_full_text_search_text_extraction_timeout: テキスト抽出処理のタイムアウト時間（秒）
   label_full_text_search_external_command_max_memory: 外部コマンドの最大使用可能メモリー
   label_full_text_search_server_url: ChupaTextサーバーのURL
-  label_full_text_search_add_search_related_parameters_in_url: search_idとsearch_nをURLパラメータに追加
+  label_full_text_search_enable_tracking: トラッキングを有効化
   label_similar_issues: 類似チケット
   label_extension: 拡張子
   label_text_extraction: テキスト抽出

--- a/lib/full_text_search/hooks/search_helper.rb
+++ b/lib/full_text_search/hooks/search_helper.rb
@@ -2,6 +2,18 @@ module FullTextSearch
   module Hooks
     module SearchHelper
       include FullTextSearch::Hooks::SettingsHelper
+
+      def search_result_entry_url(e, i)
+        if fts_enable_tracking?
+          search_parameters = {
+            "search_id" => @search_request.search_id,
+            "search_n" => i + @search_request.offset,
+          }
+        else
+          search_parameters = {}
+        end
+        e.event_url.merge(search_parameters)
+      end
     end
   end
 end

--- a/lib/full_text_search/hooks/settings_helper.rb
+++ b/lib/full_text_search/hooks/settings_helper.rb
@@ -8,6 +8,10 @@ module FullTextSearch
       def fts_display_similar_issues?
         Setting.plugin_full_text_search.display_similar_issues?
       end
+
+      def fts_add_search_related_parameters_in_url?
+        Setting.plugin_full_text_search.add_search_related_parameters_in_url?
+      end
     end
   end
 end

--- a/lib/full_text_search/hooks/settings_helper.rb
+++ b/lib/full_text_search/hooks/settings_helper.rb
@@ -9,8 +9,8 @@ module FullTextSearch
         Setting.plugin_full_text_search.display_similar_issues?
       end
 
-      def fts_add_search_related_parameters_in_url?
-        Setting.plugin_full_text_search.add_search_related_parameters_in_url?
+      def fts_enable_tracking?
+        Setting.plugin_full_text_search.enable_tracking?
       end
     end
   end

--- a/lib/full_text_search/settings.rb
+++ b/lib/full_text_search/settings.rb
@@ -20,8 +20,9 @@ module FullTextSearch
       @raw["display_similar_issues"] == TRUE_VALUE
     end
 
-    def add_search_related_parameters_in_url?
-      @raw["add_search_related_parameters_in_url"] == TRUE_VALUE
+    def enable_tracking?
+      @raw["enable_tracking"].nil? or
+        @raw["enable_tracking"] == TRUE_VALUE
     end
 
     DEFAULT_ATTACHMENT_MAX_TEXT_SIZE_IN_MB = 4

--- a/lib/full_text_search/settings.rb
+++ b/lib/full_text_search/settings.rb
@@ -20,6 +20,10 @@ module FullTextSearch
       @raw["display_similar_issues"] == TRUE_VALUE
     end
 
+    def add_search_related_parameters_in_url?
+      @raw["add_search_related_parameters_in_url"] == TRUE_VALUE
+    end
+
     DEFAULT_ATTACHMENT_MAX_TEXT_SIZE_IN_MB = 4
     def attachment_max_text_size_in_mb
       size = @raw.fetch("attachment_max_text_size_in_mb",


### PR DESCRIPTION
This PR fixes #86 .

This option decides whether include `search_id` and `search_n` in URL.

The default value of it is TRUE. (Same behavior as the current version.)
If we set FALSE to it, `search_id` and `search_n` are not included in the URL.

