### PR TITLE
Fix migration 20190925074645_add_name_index_to_fts_tags

### DIFF
--- a/db/migrate/20190925074645_add_name_index_to_fts_tags.rb
+++ b/db/migrate/20190925074645_add_name_index_to_fts_tags.rb
@@ -1,3 +1,5 @@
+require "full_text_search/migration"
+
 class AddNameIndexToFtsTags < ActiveRecord::Migration[5.2]
   def change
     return if reverting? and !table_exists?(:fts_tags)


### PR DESCRIPTION
The following error occurs when using postgreSQL and migrating 20190925074645_add_name_index_to_fts_tags.

```
Caused by:
ArgumentError: Unknown key: :with. Valid keys are: :unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :opclass
/var/lib/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/core_ext/hash/keys.rb:81:in `block in assert_valid_keys'
/var/lib/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/core_ext/hash/keys.rb:79:in `each_key'
/var/lib/redmine/vendor/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/core_ext/hash/keys.rb:79:in `assert_valid_keys'
/var/lib/redmine/vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:1138:in `add_index_options'
/var/lib/redmine/vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:465:in `add_index'
...
```

It seems to fail to override add_index_options, so I've fixed it.