### PR TITLE
Fix error of deleted directory in repository

### DIFF
--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -34,11 +34,11 @@ module FullTextSearch
       repository = changeset.repository
       return if repository.nil?
 
-      entry = RepositoryEntry.new(repository,
-                                  @record.path,
-                                  changeset.identifier)
       case @record.action
       when "A", "M", "R"
+        entry = RepositoryEntry.new(repository,
+                                  @record.path,
+                                  changeset.identifier)
         return unless entry.file?
         return if find_newer_fts_targets.exists?
 


### PR DESCRIPTION
Gitでフォルダ削除した後、
`bin/rails full_text_search:synchronize`
の処理で次のようなエラーが出るようになりました。

`fatal: Not a valid object name 70～bd:myapp`

発生箇所を探したところ、
change_mapper.rb の upsert_fts_target関数の中の 
  `entry = RepositoryEntry.new(～)`
の処理でエラーが出ていました。

このentryは 後段の
`
    case @record.action
    when "A", "M", "R"
`
の中で利用されていて
    when "D"
では不要なようなので
  entry = RepositoryEntry.new(～)
を
    case @record.action
    when "A", "M", "R"
の中で処理したほうが良いと思ったのですが、
如何でしょうか。
