### PR TITLE
Add missing icon classes for search options

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -32,7 +32,7 @@
     </p>
 
     <fieldset class="collapsible collapsed">
-      <legend onclick="toggleFieldset(this);"><%= l(:label_options) %></legend>
+      <legend onclick="toggleFieldset(this);" class="icon icon-collapsed"><%= l(:label_options) %></legend>
       <div id="options-content" style="display:none;">
         <p><%= project_select_tag %></p>
         <p><label><%= form.check_box "titles_only", name: "titles_only" %>


### PR DESCRIPTION
If we don't specify them, search options collapsed/expanded icon is broken.