### PR TITLE
Enable sort function by registered time on the search page

### DIFF
--- a/app/views/search/index.api.rsb
+++ b/app/views/search/index.api.rsb
@@ -3,13 +3,15 @@ api.array :results, api_meta(:total_count => @result_set.n_hits,
                              :limit => @search_request.limit) do
   @result_set.each do |record|
     api.result do
-      api.id          record.event_id
-      api.title       record.event_highlighted_title
-      api.type        record.event_type
-      api.url         url_for(record.event_url(:only_path => false))
-      api.description record.event_content_snippets.join("\n")
-      api.datetime    record.event_datetime
-      api.rank        record.rank
+      api.id               record.event_id
+      api.title            record.event_highlighted_title
+      api.type             record.event_type
+      api.url              url_for(record.event_url(:only_path => false))
+      api.description      record.event_content_snippets.join("\n")
+      api.datetime         record.event_datetime
+      api.last_modified_at record.last_modified_at
+      api.registered_at    record.registered_at
+      api.rank             record.rank
     end
   end
 end

--- a/app/views/search/index.api.rsb
+++ b/app/views/search/index.api.rsb
@@ -8,6 +8,7 @@ api.array :results, api_meta(:total_count => @result_set.n_hits,
       api.type             record.event_type
       api.url              url_for(record.event_url(:only_path => false))
       api.description      record.event_content_snippets.join("\n")
+      # TODO: 'datetime' is deprecated but maintained for backward compatibility. Use 'last_modified_at' or 'registered_at' explicitly.
       api.datetime         record.event_datetime
       api.last_modified_at record.last_modified_at
       api.registered_at    record.registered_at

--- a/app/views/search/index.api.rsb
+++ b/app/views/search/index.api.rsb
@@ -8,7 +8,8 @@ api.array :results, api_meta(:total_count => @result_set.n_hits,
       api.type             record.event_type
       api.url              url_for(record.event_url(:only_path => false))
       api.description      record.event_content_snippets.join("\n")
-      # TODO: 'datetime' is deprecated but maintained for backward compatibility. Use 'last_modified_at' or 'registered_at' explicitly.
+      # 'datetime' is deprecated but maintained for backward compatibility.
+      # Use 'last_modified_at' or 'registered_at' explicitly.
       api.datetime         record.event_datetime
       api.last_modified_at record.last_modified_at
       api.registered_at    record.registered_at

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -58,6 +58,10 @@
               <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_at) %>
             </label>
+            <label>
+              <%= form.radio_button "order_target", "registered_at", name: "order_target" %>
+              <%= l(:label_full_text_search_order_target_registered_at) %>
+            </label>
           </p>
           <p>
             <label>
@@ -104,6 +108,12 @@
                              tag.i(class: "fas fa-clock") + " " +
                                l(:label_full_text_search_order_target_last_modified_at),
                              url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
+        </li>
+        <li>
+          <%= link_to_unless(@search_request.order_target == "registered_at",
+                             tag.i(class: "fas fa-clock") + " " +
+                               l(:label_full_text_search_order_target_registered_at),
+                             url_for(@search_request.to_params(order_target: "registered_at"))) %>
         </li>
       </ul>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,8 +55,8 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <%= form.radio_button "order_target", "date", name: "order_target" %>
-              <%= l(:label_full_text_search_order_target_date) %>
+              <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
+              <%= l(:label_full_text_search_order_target_last_modified_at) %>
             </label>
           </p>
           <p>
@@ -100,10 +100,10 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <%= link_to_unless(@search_request.order_target == "date",
+          <%= link_to_unless(@search_request.order_target == "last_modified_at",
                              tag.i(class: "fas fa-clock") + " " +
-                               l(:label_full_text_search_order_target_date),
-                             url_for(@search_request.to_params(order_target: "date"))) %>
+                               l(:label_full_text_search_order_target_last_modified_at),
+                             url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
         </li>
       </ul>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,7 +55,9 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <%= form.radio_button "order_target", "last_modified_time", name: "order_target" %>
+              <!-- TODO: 'date' is deprecated but maintained for backward compatibility. -->
+              <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
+              <%= form.radio_button "order_target", "last_modified_time", checked: ["date", "last_modified_time"].include?(@search_request.order_target), name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_time) %>
             </label>
             <label>
@@ -104,7 +106,9 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <%= link_to_unless(@search_request.order_target == "last_modified_time",
+          <!-- TODO: 'date' is deprecated but maintained for backward compatibility. -->
+          <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
+          <%= link_to_unless(["date", "last_modified_time"].include?(@search_request.order_target),
                              tag.i(class: "fas fa-pen") + " " +
                                l(:label_full_text_search_order_target_last_modified_time),
                              url_for(@search_request.to_params(order_target: "last_modified_time"))) %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -56,11 +56,11 @@
             </label>
             <label>
               <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
-              <%= l(:label_full_text_search_order_target_last_modified_at) %>
+              <%= l(:label_full_text_search_order_target_last_modified_time) %>
             </label>
             <label>
               <%= form.radio_button "order_target", "registered_at", name: "order_target" %>
-              <%= l(:label_full_text_search_order_target_registered_at) %>
+              <%= l(:label_full_text_search_order_target_registered_time) %>
             </label>
           </p>
           <p>
@@ -106,13 +106,13 @@
         <li>
           <%= link_to_unless(@search_request.order_target == "last_modified_at",
                              tag.i(class: "fas fa-clock") + " " +
-                               l(:label_full_text_search_order_target_last_modified_at),
+                               l(:label_full_text_search_order_target_last_modified_time),
                              url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
         </li>
         <li>
           <%= link_to_unless(@search_request.order_target == "registered_at",
                              tag.i(class: "far fa-clock") + " " +
-                               l(:label_full_text_search_order_target_registered_at),
+                               l(:label_full_text_search_order_target_registered_time),
                              url_for(@search_request.to_params(order_target: "registered_at"))) %>
         </li>
       </ul>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -105,13 +105,13 @@
         </li>
         <li>
           <%= link_to_unless(@search_request.order_target == "last_modified_at",
-                             tag.i(class: "fas fa-clock") + " " +
+                             tag.i(class: "fas fa-pen") + " " +
                                l(:label_full_text_search_order_target_last_modified_time),
                              url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
         </li>
         <li>
           <%= link_to_unless(@search_request.order_target == "registered_at",
-                             tag.i(class: "far fa-clock") + " " +
+                             tag.i(class: "fas fa-calendar") + " " +
                                l(:label_full_text_search_order_target_registered_time),
                              url_for(@search_request.to_params(order_target: "registered_at"))) %>
         </li>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -111,7 +111,7 @@
         </li>
         <li>
           <%= link_to_unless(@search_request.order_target == "registered_at",
-                             tag.i(class: "fas fa-clock") + " " +
+                             tag.i(class: "far fa-clock") + " " +
                                l(:label_full_text_search_order_target_registered_at),
                              url_for(@search_request.to_params(order_target: "registered_at"))) %>
         </li>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,11 +55,11 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <%= form.radio_button "order_target", "last_modified_at", name: "order_target" %>
+              <%= form.radio_button "order_target", "last_modified_time", name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_time) %>
             </label>
             <label>
-              <%= form.radio_button "order_target", "registered_at", name: "order_target" %>
+              <%= form.radio_button "order_target", "registered_time", name: "order_target" %>
               <%= l(:label_full_text_search_order_target_registered_time) %>
             </label>
           </p>
@@ -104,16 +104,16 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <%= link_to_unless(@search_request.order_target == "last_modified_at",
+          <%= link_to_unless(@search_request.order_target == "last_modified_time",
                              tag.i(class: "fas fa-pen") + " " +
                                l(:label_full_text_search_order_target_last_modified_time),
-                             url_for(@search_request.to_params(order_target: "last_modified_at"))) %>
+                             url_for(@search_request.to_params(order_target: "last_modified_time"))) %>
         </li>
         <li>
-          <%= link_to_unless(@search_request.order_target == "registered_at",
+          <%= link_to_unless(@search_request.order_target == "registered_time",
                              tag.i(class: "fas fa-calendar") + " " +
                                l(:label_full_text_search_order_target_registered_time),
-                             url_for(@search_request.to_params(order_target: "registered_at"))) %>
+                             url_for(@search_request.to_params(order_target: "registered_time"))) %>
         </li>
       </ul>
     </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -57,7 +57,10 @@
             <label>
               <%# 'date' is deprecated but maintained for backward compatibility. %>
               <%# Use 'last_modified_time' or 'registered_time' explicitly. %>
-              <%= form.radio_button "order_target", "last_modified_time", checked: ["date", "last_modified_time"].include?(@search_request.order_target), name: "order_target" %>
+              <%= form.radio_button "order_target",
+                                    "last_modified_time",
+                                    checked: ["date", "last_modified_time"].include?(@search_request.order_target),
+                                    name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_time) %>
             </label>
             <label>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,8 +55,8 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <!-- 'date' is deprecated but maintained for backward compatibility. -->
-              <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
+              <%# 'date' is deprecated but maintained for backward compatibility. %>
+              <%# Use 'last_modified_time' or 'registered_time' explicitly. %>
               <%= form.radio_button "order_target", "last_modified_time", checked: ["date", "last_modified_time"].include?(@search_request.order_target), name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_time) %>
             </label>
@@ -106,8 +106,8 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <!-- 'date' is deprecated but maintained for backward compatibility. -->
-          <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
+          <%# 'date' is deprecated but maintained for backward compatibility. %>
+          <%# Use 'last_modified_time' or 'registered_time' explicitly. %>
           <%= link_to_unless(["date", "last_modified_time"].include?(@search_request.order_target),
                              tag.i(class: "fas fa-pen") + " " +
                                l(:label_full_text_search_order_target_last_modified_time),

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -189,7 +189,15 @@
               <li><%= snippet %></li>
             <% end %>
           </ol>
-        <span class="author"><%= format_time(e.event_datetime) %></span></dd>
+          <span class="last-modified">
+            <i class="fas fa-pen"></i>:
+            <%= format_time(e.last_modified_at) %>
+          </span>
+          <span class="registered">
+            <i class="fas fa-calendar"></i>:
+            <%= format_time(e.registered_at) %>
+          </span>
+        </dd>
       <% end %>
     </dl>
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,7 +55,7 @@
               <%= l(:label_full_text_search_order_target_score) %>
             </label>
             <label>
-              <!-- TODO: 'date' is deprecated but maintained for backward compatibility. -->
+              <!-- 'date' is deprecated but maintained for backward compatibility. -->
               <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
               <%= form.radio_button "order_target", "last_modified_time", checked: ["date", "last_modified_time"].include?(@search_request.order_target), name: "order_target" %>
               <%= l(:label_full_text_search_order_target_last_modified_time) %>
@@ -106,7 +106,7 @@
                              url_for(@search_request.to_params(order_target: "score"))) %>
         </li>
         <li>
-          <!-- TODO: 'date' is deprecated but maintained for backward compatibility. -->
+          <!-- 'date' is deprecated but maintained for backward compatibility. -->
           <!-- Use 'last_modified_time' or 'registered_time' explicitly. -->
           <%= link_to_unless(["date", "last_modified_time"].include?(@search_request.order_target),
                              tag.i(class: "fas fa-pen") + " " +

--- a/assets/stylesheets/search.css
+++ b/assets/stylesheets/search.css
@@ -82,6 +82,11 @@ ol.search-snippets li {
   padding: 0.25em 0;
 }
 
+.last-modified::after {
+  content: '|';
+  padding: 0 0.25em;
+}
+
 .keyword {
   background-color: #FCFD8D;
 }

--- a/assets/stylesheets/search.css
+++ b/assets/stylesheets/search.css
@@ -82,7 +82,7 @@ ol.search-snippets li {
   padding: 0.25em 0;
 }
 
-.last-modified::after {
+#search-results .last-modified::after {
   content: '|';
   padding: 0 0.25em;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   label_full_text_search_result_order_type: Sort order
   label_full_text_search_order_target_score: score
   label_full_text_search_order_target_last_modified_at: updated at
+  label_full_text_search_order_target_registered_at: created at
   label_full_text_search_order_type_asc: asc
   label_full_text_search_order_type_desc: desc
   label_full_text_search_display_score: Display score

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
   label_full_text_search_result_order_target: Sort by
   label_full_text_search_result_order_type: Sort order
   label_full_text_search_order_target_score: score
-  label_full_text_search_order_target_date: updated at
+  label_full_text_search_order_target_last_modified_at: updated at
   label_full_text_search_order_type_asc: asc
   label_full_text_search_order_type_desc: desc
   label_full_text_search_display_score: Display score

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,8 +4,8 @@ en:
   label_full_text_search_result_order_target: Sort by
   label_full_text_search_result_order_type: Sort order
   label_full_text_search_order_target_score: score
-  label_full_text_search_order_target_last_modified_at: updated at
-  label_full_text_search_order_target_registered_at: created at
+  label_full_text_search_order_target_last_modified_time: last modified
+  label_full_text_search_order_target_registered_time: registered
   label_full_text_search_order_type_asc: asc
   label_full_text_search_order_type_desc: desc
   label_full_text_search_display_score: Display score

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
   label_full_text_search_result_order_type: 並び順
   label_full_text_search_order_target_score: スコア
   label_full_text_search_order_target_last_modified_at: 更新日時
+  label_full_text_search_order_target_registered_at: 作成日時
   label_full_text_search_order_type_asc: 昇順
   label_full_text_search_order_type_desc: 降順
   label_full_text_search_display_score: スコアを表示

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,7 +4,7 @@ ja:
   label_full_text_search_result_order_target: 並び替え対象
   label_full_text_search_result_order_type: 並び順
   label_full_text_search_order_target_score: スコア
-  label_full_text_search_order_target_date: 更新日時
+  label_full_text_search_order_target_last_modified_at: 更新日時
   label_full_text_search_order_type_asc: 昇順
   label_full_text_search_order_type_desc: 降順
   label_full_text_search_display_score: スコアを表示

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,8 +4,8 @@ ja:
   label_full_text_search_result_order_target: 並び替え対象
   label_full_text_search_result_order_type: 並び順
   label_full_text_search_order_target_score: スコア
-  label_full_text_search_order_target_last_modified_at: 更新日時
-  label_full_text_search_order_target_registered_at: 作成日時
+  label_full_text_search_order_target_last_modified_time: 更新日時
+  label_full_text_search_order_target_registered_time: 作成日時
   label_full_text_search_order_type_asc: 昇順
   label_full_text_search_order_type_desc: 降順
   label_full_text_search_display_score: スコアを表示

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -242,7 +242,7 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      when "date"
+      when "last_modified_at"
         [
           "#{direction}last_modified_at",
         ]

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -226,6 +226,7 @@ module FullTextSearch
         "content_snippets",
         "id",
         "last_modified_at",
+        "registered_at",
         "project_id",
         "source_id",
         "source_type_id",
@@ -245,6 +246,10 @@ module FullTextSearch
       when "last_modified_at"
         [
           "#{direction}last_modified_at",
+        ]
+      when "registered_at"
+        [
+          "#{direction}registered_at",
         ]
       else
         # TODO: -_score is useful?
@@ -302,6 +307,7 @@ module FullTextSearch
         # Rails.logger.debug(title: record["title_digest"],
         #                    description: record["description_digest"])
         record["last_modified_at"] += Target.time_offset
+        record["registered_at"] += Target.time_offset
         record["highlighted_title"] = record["highlighted_title"].html_safe
         record["content_snippets"] = record["content_snippets"].collect do |snippet|
           snippet.html_safe

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -243,7 +243,9 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      when "last_modified_time"
+      # TODO: Supporting the `date` parameter for backward compatibility,
+      # but it will be deprecated in the future. Use `last_modified_time` instead.
+      when "data", "last_modified_time"
         [
           "#{direction}last_modified_at",
         ]

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -243,7 +243,7 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      # TODO: 'date' is deprecated but maintained for backward compatibility.
+      # 'date' is deprecated but maintained for backward compatibility.
       # Use 'last_modified_time' or 'registered_time' explicitly.
       when "date", "last_modified_time"
         [

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -243,9 +243,9 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      # TODO: Supporting the `date` parameter for backward compatibility,
-      # but it will be deprecated in the future. Use `last_modified_time` instead.
-      when "data", "last_modified_time"
+      # TODO: 'date' is deprecated but maintained for backward compatibility.
+      # Use 'last_modified_time' or 'registered_time' explicitly.
+      when "date", "last_modified_time"
         [
           "#{direction}last_modified_at",
         ]

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -243,11 +243,11 @@ module FullTextSearch
         direction = ""
       end
       case @request.order_target
-      when "last_modified_at"
+      when "last_modified_time"
         [
           "#{direction}last_modified_at",
         ]
-      when "registered_at"
+      when "registered_time"
         [
           "#{direction}registered_at",
         ]

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -290,6 +290,12 @@ module FullTextSearch
                                                        "order_type" => "desc"),
                          ],
                          [
+                           "created at",
+                           expected_search_path,
+                           common_search_options.merge("order_target" => "registered_at",
+                                                       "order_type" => "desc"),
+                         ],
+                         [
                            "asc",
                            expected_search_path,
                            common_search_options.merge("order_target" => "score",

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -286,7 +286,7 @@ module FullTextSearch
                          [
                            "updated at",
                            expected_search_path,
-                           common_search_options.merge("order_target" => "date",
+                           common_search_options.merge("order_target" => "last_modified_at",
                                                        "order_type" => "desc"),
                          ],
                          [

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -291,13 +291,13 @@ module FullTextSearch
                          [
                            "last modified",
                            expected_search_path,
-                           common_search_options.merge("order_target" => "last_modified_at",
+                           common_search_options.merge("order_target" => "last_modified_time",
                                                        "order_type" => "desc"),
                          ],
                          [
                            "registered",
                            expected_search_path,
-                           common_search_options.merge("order_target" => "registered_at",
+                           common_search_options.merge("order_target" => "registered_time",
                                                        "order_type" => "desc"),
                          ],
                          [

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -218,6 +218,8 @@ module FullTextSearch
         if item.respond_to?(:created_on)
           last_modified_at ||= item.created_on
           registered_at = item.created_on
+        else
+          registered_at = last_modified_at
         end
         {
           "id" => item.id,
@@ -226,7 +228,7 @@ module FullTextSearch
           "url" => item_url(item),
           "description" => detail[:description] || "",
           "last_modified_at" => last_modified_at&.iso8601,
-          "registered_at" => registered_at&.iso8601 || last_modified_at&.iso8601,
+          "registered_at" => registered_at&.iso8601,
           "datetime" => last_modified_at&.iso8601,
           "rank" => detail[:rank],
         }

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -284,13 +284,13 @@ module FullTextSearch
           assert_equal([
                          ["score", nil, nil],
                          [
-                           "updated at",
+                           "last modified",
                            expected_search_path,
                            common_search_options.merge("order_target" => "last_modified_at",
                                                        "order_type" => "desc"),
                          ],
                          [
-                           "created at",
+                           "registered",
                            expected_search_path,
                            common_search_options.merge("order_target" => "registered_at",
                                                        "order_type" => "desc"),

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -197,26 +197,26 @@ module FullTextSearch
     def format_api_results(items, total_count: nil)
       results = items.collect do |item, detail|
         item.reload
-        datetime = nil
+        last_modified_at = nil
         if item.respond_to?(:customized)
           customized = item.customized
           customized.reload
           if customized.respond_to?(:updated_on)
-            datetime ||= customized.updated_on
+            last_modified_at ||= customized.updated_on
           end
           if customized.respond_to?(:created_on)
-            datetime ||= customized.created_on
+            last_modified_at ||= customized.created_on
           end
         end
-        datetime ||= item.committed_on if item.respond_to?(:committed_on)
+        last_modified_at ||= item.committed_on if item.respond_to?(:committed_on)
         if item.respond_to?(:changeset)
           changeset = item.changeset
           changeset.reload
-          datetime ||= changeset.committed_on
+          last_modified_at ||= changeset.committed_on
         end
-        datetime ||= item.updated_on if item.respond_to?(:updated_on)
+        last_modified_at ||= item.updated_on if item.respond_to?(:updated_on)
         if item.respond_to?(:created_on)
-          datetime ||= item.created_on
+          last_modified_at ||= item.created_on
           registered_at = item.created_on
         end
         {
@@ -225,9 +225,9 @@ module FullTextSearch
           "type" => detail[:type] || item.class.name.underscore.dasherize,
           "url" => item_url(item),
           "description" => detail[:description] || "",
-          "last_modified_at" => datetime&.iso8601,
-          "registered_at" => registered_at&.iso8601 || datetime&.iso8601,
-          "datetime" => datetime&.iso8601,
+          "last_modified_at" => last_modified_at&.iso8601,
+          "registered_at" => registered_at&.iso8601 || last_modified_at&.iso8601,
+          "datetime" => last_modified_at&.iso8601,
           "rank" => detail[:rank],
         }
       end

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -215,13 +215,18 @@ module FullTextSearch
           datetime ||= changeset.committed_on
         end
         datetime ||= item.updated_on if item.respond_to?(:updated_on)
-        datetime ||= item.created_on if item.respond_to?(:created_on)
+        if item.respond_to?(:created_on)
+          datetime ||= item.created_on
+          registered_at = item.created_on
+        end
         {
           "id" => item.id,
           "title" => detail[:title] || item_title(item),
           "type" => detail[:type] || item.class.name.underscore.dasherize,
           "url" => item_url(item),
           "description" => detail[:description] || "",
+          "last_modified_at" => datetime&.iso8601,
+          "registered_at" => registered_at&.iso8601 || datetime&.iso8601,
           "datetime" => datetime&.iso8601,
           "rank" => detail[:rank],
         }

--- a/test/unit/full_text_search/searcher_test.rb
+++ b/test/unit/full_text_search/searcher_test.rb
@@ -83,7 +83,7 @@ module FullTextSearch
                    targets.collect(&:source_record).sort_by(&:id))
     end
 
-    def test_results_ordered_by_descending_registered_time
+    def test_order_registered_time_desc
       parameters = {
         order_target: "registered_time",
         order_type: "desc",
@@ -100,7 +100,7 @@ module FullTextSearch
       assert_equal(ordered_news, searched_news)
     end
 
-    def test_results_ordered_by_ascending_registered_time
+    def test_order_registered_time_asc
       parameters = {
         order_target: "registered_time",
         order_type: "asc",

--- a/test/unit/full_text_search/searcher_test.rb
+++ b/test/unit/full_text_search/searcher_test.rb
@@ -82,5 +82,41 @@ module FullTextSearch
       assert_equal([issue],
                    targets.collect(&:source_record).sort_by(&:id))
     end
+
+    def test_results_ordered_by_descending_registered_time
+      parameters = {
+        order_target: "registered_time",
+        order_type: "desc",
+        search_id: @project.id,
+        news: "1",
+        attachments: "0",
+        limit: "-1"
+      }
+      targets = search(parameters).records
+      searched_news_ids = targets.collect(&:source_id)
+      ordered_news = @project
+                       .news
+                       .order(created_on: :desc)
+                       .ids
+      assert_equal(ordered_news, searched_news_ids)
+    end
+
+    def test_results_ordered_by_ascending_registered_time
+      parameters = {
+        order_target: "registered_time",
+        order_type: "asc",
+        search_id: @project.id,
+        news: "1",
+        attachments: "0",
+        limit: "-1"
+      }
+      targets = search(parameters).records
+      searched_news_ids = targets.collect(&:source_id)
+      ordered_news = @project
+                       .news
+                       .order(created_on: :asc)
+                       .ids
+      assert_equal(ordered_news, searched_news_ids)
+    end
   end
 end

--- a/test/unit/full_text_search/searcher_test.rb
+++ b/test/unit/full_text_search/searcher_test.rb
@@ -87,7 +87,6 @@ module FullTextSearch
       parameters = {
         order_target: "registered_time",
         order_type: "desc",
-        search_id: @project.id,
         news: "1",
         attachments: "0",
         limit: "-1"
@@ -104,7 +103,6 @@ module FullTextSearch
       parameters = {
         order_target: "registered_time",
         order_type: "asc",
-        search_id: @project.id,
         news: "1",
         attachments: "0",
         limit: "-1"

--- a/test/unit/full_text_search/searcher_test.rb
+++ b/test/unit/full_text_search/searcher_test.rb
@@ -93,12 +93,11 @@ module FullTextSearch
         limit: "-1"
       }
       targets = search(parameters).records
-      searched_news_ids = targets.collect(&:source_id)
+      searched_news = targets.collect(&:source_record)
       ordered_news = @project
                        .news
                        .order(created_on: :desc)
-                       .ids
-      assert_equal(ordered_news, searched_news_ids)
+      assert_equal(ordered_news, searched_news)
     end
 
     def test_results_ordered_by_ascending_registered_time
@@ -111,12 +110,11 @@ module FullTextSearch
         limit: "-1"
       }
       targets = search(parameters).records
-      searched_news_ids = targets.collect(&:source_id)
+      searched_news = targets.collect(&:source_record)
       ordered_news = @project
                        .news
                        .order(created_on: :asc)
-                       .ids
-      assert_equal(ordered_news, searched_news_ids)
+      assert_equal(ordered_news, searched_news)
     end
   end
 end


### PR DESCRIPTION
GitHub: fix #115
Related PR: https://github.com/clear-code/redmine_full_text_search/pull/118

## What I did
- Deprecated the `date` parameter and ensured backward compatibility in the process
- Changed to use `registered_time` or `last_modified_time` instead of `date` parameter
- Changed the icons for registered time and last modified time to make them more easily distinguishable.
- Display the registered time and last modified time on the search page
- Added sort option by the registered time on the search page
    - ref: http://localhost:3000/search 
- Added test cases for order by registered_time

| Before | After |
| --- | --- |
| <img width=100% alt="Screenshot 2023-12-20 at 20 29 57" src="https://github.com/otegami/redmine_full_text_search/assets/45173523/4817d596-e7fe-4336-b356-df5c2550ae21"> | <img width=100% alt="Screenshot 2023-12-29 at 9 20 53" src="https://github.com/clear-code/redmine_full_text_search/assets/45173523/14818055-4015-40e0-83bd-8c3ac30fade2"> |

## What I checked
I checked whether the pgroonga command include `registered_at` in sort_key or not. And it does.

<details>
<summary> `'slices[type_filtered].sort_keys', '-registered_at'` </summary>

- Steps
    - I access to the search page
        - http://localhost:3000/search 
    - I sort the `News` by using registered time and check the logs rails generated.
```console
SELECT pgroonga_command('select',
  ARRAY[
    'table', pgroonga_table_name('fts_targets_index_pgroonga'),
    'match_columns', 'title * 100 || scorer_tf_at_most(content, 5)', 'query_flags', 'ALLOW_COLUMN|ALLOW_LEADING_NOT|QUERY_NO_SYNTAX_ERROR', 'filter', 'in_values(project_id, 1, 2, 3, 4, 5, 6) &! is_private == true &! ( in_values(project_id, 3, 4, 5, 6) && ( source_type_id == 6 || container_type_id == 6 ) ) && pgroonga_tuple_is_alive(ctid)', 'output_columns', '_id', 'limit', '0', 'drilldowns[source_type].keys', 'source_type_id', 'drilldowns[source_type].limit', '-1', 'drilldowns[container_type].keys', 'container_type_id', 'drilldowns[container_type].limit', '-1', 'slices[type_filtered].filter', 'all_records() &! source_type_id == 2 &! container_type_id == 2 &! source_type_id == 7 &! container_type_id == 7 &! source_type_id == 10 &! container_type_id == 10 &! source_type_id == 3 &! container_type_id == 3 &! source_type_id == 8 &! container_type_id == 8 &! source_type_id == 5 &! container_type_id == 5 &! source_type_id == 11 &! container_type_id == 11', 'slices[type_filtered].columns[highlighted_title].stage', 'output', 'slices[type_filtered].columns[highlighted_title].type', 'ShortText', 'slices[type_filtered].columns[highlighted_title].flags', 'COLUMN_SCALAR', 'slices[type_filtered].columns[highlighted_title].value', 'highlight_html(title)', 'slices[type_filtered].columns[content_snippets].stage', 'output', 'slices[type_filtered].columns[content_snippets].type', 'ShortText', 'slices[type_filtered].columns[content_snippets].flags', 'COLUMN_VECTOR', 'slices[type_filtered].columns[content_snippets].value', 'snippet_html(content)', 'slices[type_filtered].drilldowns[tag].keys', 'tag_ids', 'slices[type_filtered].drilldowns[tag].limit', '-1', 'slices[type_filtered].drilldowns[tag].sort_keys', '-_nsubrecs', 'slices[type_filtered].output_columns', '_score, content_snippets, id, last_modified_at, registered_at, project_id, source_id, source_type_id, title, highlighted_title, tag_ids', 'slices[type_filtered].sort_keys', '-registered_at', 'slices[type_filtered].offset', '0', 'slices[type_filtered].limit', '10'
  ]
)
```

</details>