### PR TITLE
Upgrade actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
             ruby-version: "3.1"
             rdbms: "PostgreSQL"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}


### PR DESCRIPTION
## Why I did
There is a deprecated message like the following at GitHub Actions.
- Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.

ref: https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400