### PR TITLE
Support Redmine master

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,8 @@
+# For backward compatibility with old version of Redmine <= v5.1.
+# ApplicationRecord is used as the default parent class for all models.
+# ref: https://www.redmine.org/issues/38975
+unless defined?(ApplicationRecord)
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/app/models/fts_query_expansion.rb
+++ b/app/models/fts_query_expansion.rb
@@ -1,4 +1,4 @@
-class FtsQueryExpansion < ActiveRecord::Base
+class FtsQueryExpansion < ApplicationRecord
   if respond_to?(:connection_db_config)
     adapter = connection_db_config.adapter
   else

--- a/app/models/full_text_search/issue_content.rb
+++ b/app/models/full_text_search/issue_content.rb
@@ -1,4 +1,4 @@
 module FullTextSearch
-  class IssueContent < ActiveRecord::Base
+  class IssueContent < ApplicationRecord
   end
 end

--- a/app/models/full_text_search/tag.rb
+++ b/app/models/full_text_search/tag.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationRecord
     self.table_name = :fts_tags
     belongs_to :type, class_name: "FullTextSearch::TagType"
 

--- a/app/models/full_text_search/tag_type.rb
+++ b/app/models/full_text_search/tag_type.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class TagType < ActiveRecord::Base
+  class TagType < ApplicationRecord
     self.table_name = :fts_tag_types
     has_many :tags, foreign_key: "type_id"
 

--- a/app/models/full_text_search/target.rb
+++ b/app/models/full_text_search/target.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Target < ActiveRecord::Base
+  class Target < ApplicationRecord
     self.table_name = :fts_targets
 
     if respond_to?(:connection_db_config)

--- a/app/models/full_text_search/type.rb
+++ b/app/models/full_text_search/type.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Type < ActiveRecord::Base
+  class Type < ApplicationRecord
     self.table_name = :fts_types
 
     class << self

--- a/config/initializers/schema_format.rb
+++ b/config/initializers/schema_format.rb
@@ -1,4 +1,5 @@
 # This is just for running test.
 # This isn't used normal use case.
 # Redmine doesn't use plugins/*/config/initializers/*.rb
-ActiveRecord::Base.schema_format = :sql
+active_record = ActiveRecord.respond_to?(:schema_format=) ? ActiveRecord : ActiveRecord::Base
+active_record.schema_format = :sql

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :full_text_search do
   version '1.0.4'
   url 'https://github.com/clear-code/redmine_full_text_search'
   author_url 'https://github.com/clear-code'
-  directory __dir__
+  directory File.dirname(File.absolute_path(__FILE__))
   settings partial: "settings/full_text_search"
 end
 

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -104,7 +104,11 @@ module FullTextSearch
     def fixture_file_path(name)
       dir = File.dirname(__FILE__)
       path = Pathname(File.join(dir, "..", "..", "files", name)).expand_path
-      fixture_path = Pathname(self.class.fixture_path)
+      fixture_path = if self.class.respond_to?(:fixture_paths=)
+                       Pathname(self.class.fixture_paths.first)
+                     else
+                       Pathname(self.class.fixture_path)
+                     end
       fixture_path += "files" if Rails::VERSION::MAJOR >= 6
       path.relative_path_from(fixture_path)
     end


### PR DESCRIPTION
close: https://github.com/clear-code/redmine_full_text_search/issues/126

- Rails uses the ApplicationRecord as a default parent class of all models instead of ActiveRecord::Base
  - ref: https://www.redmine.org/issues/38975
  - ref: https://rubyonrails.org/2016/6/30/Rails-5-0-final
- In Rails 7, the .schema_format= API is moved from ActiveRecord::Base to ActiveRecord
  - ref: https://github.com/rails/rails/pull/42442
- Use the actual path under /plugins using symbolic links
  - Because `__dir__` resolves the symbolic link
- In Rails v7.1, ActiveSupport::TestCase.fixture_path will be deprecated
  - ref: https://github.com/rails/rails/pull/47675
  - ref: https://github.com/rails/rails/pull/47764

## What I didn't
- Interact with all the provided features
  - I determined there were no errors since the CI passed