### PR TITLE
Adjust `.schema_format=` API Usage for Rails 7 Compatibility

### DIFF
--- a/config/initializers/schema_format.rb
+++ b/config/initializers/schema_format.rb
@@ -1,4 +1,6 @@
 # This is just for running test.
 # This isn't used normal use case.
 # Redmine doesn't use plugins/*/config/initializers/*.rb
-ActiveRecord::Base.schema_format = :sql
+# `ActiveRecord::Base.schema_format=` is removed from Rails v7 but maintained for backward compatibility.
+active_record = ActiveRecord.respond_to?(:schema_format=) ? ActiveRecord : ActiveRecord::Base
+active_record.schema_format = :sql

--- a/config/initializers/schema_format.rb
+++ b/config/initializers/schema_format.rb
@@ -1,6 +1,9 @@
 # This is just for running test.
 # This isn't used normal use case.
 # Redmine doesn't use plugins/*/config/initializers/*.rb
-# `ActiveRecord::Base.schema_format=` is removed from Rails v7 but maintained for backward compatibility.
-active_record = ActiveRecord.respond_to?(:schema_format=) ? ActiveRecord : ActiveRecord::Base
-active_record.schema_format = :sql
+if ActiveRecord.respond_to?(:schema_format=)
+  # For Rails >= 7
+  ActiveRecord.schema_format = :sql
+else
+  ActiveRecord::Base.schema_format = :sql
+end


### PR DESCRIPTION
related: #126 

In Rails 7, the .schema_format= API is moved from ActiveRecord::Base to ActiveRecord
- ref: https://github.com/rails/rails/pull/42445

It also solved the following CI failure.
```    
NoMethodError: undefined method `schema_format=' for ActiveRecord::Base:Class
```