### PR TITLE
Ensure using the path in Redmine for plugin directory

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :full_text_search do
   version '1.0.4'
   url 'https://github.com/clear-code/redmine_full_text_search'
   author_url 'https://github.com/clear-code'
-  directory __dir__
+  directory File.dirname(File.absolute_path(__FILE__))
   settings partial: "settings/full_text_search"
 end
 

--- a/init.rb
+++ b/init.rb
@@ -5,6 +5,10 @@ Redmine::Plugin.register :full_text_search do
   version '1.0.4'
   url 'https://github.com/clear-code/redmine_full_text_search'
   author_url 'https://github.com/clear-code'
+  # We can't use __dir__ here because ensuring plugin path is correctly registered even when symbolic links are used.
+  # For example, _dir__ and __FILE__ are the followings using `ln -s /redmine/real_path_to_plugin/ /redmine/symlink_path_to_plugin/`:
+  #   * __dir__: /redmine/real_path_to_plugin/
+  #   * __FILE__: ./symlink_path_to_plugin/init.rb
   directory File.dirname(File.absolute_path(__FILE__))
   settings partial: "settings/full_text_search"
 end

--- a/init.rb
+++ b/init.rb
@@ -13,9 +13,9 @@ Redmine::Plugin.register :full_text_search do
   #
   # But __dir__ doesn't work when we use a symbolic link:
   #
-  #  $ git clone https://github.com/clear-code/redmine_full_text_search.git
-  #  $ cd redmine/plugins
-  #  $ ln -s ../../redmine_full_text_search full_text_search
+  #   $ git clone https://github.com/clear-code/redmine_full_text_search.git
+  #   $ cd redmine/plugins
+  #   $ ln -s ../../redmine_full_text_search full_text_search
   #
   # In this case, __dir__ and __FILE__ are the followings:
   #
@@ -23,7 +23,7 @@ Redmine::Plugin.register :full_text_search do
   #   __FILE__: ./full_text_search/init.rb
   #
   # Note that "/tmp/redmine_full_text_search" isn't a path in Redmine's plugin directory (redmine/plugins/).
-  # Redmine assumes that this is a patch in Redmine's plugin directory. So we need to compute this from
+  # Redmine assumes that this is a path in Redmine's plugin directory. So we need to compute this from
   # __FILE__ not __dir__.
   directory File.dirname(File.absolute_path(__FILE__))
   settings partial: "settings/full_text_search"

--- a/init.rb
+++ b/init.rb
@@ -5,10 +5,26 @@ Redmine::Plugin.register :full_text_search do
   version '1.0.4'
   url 'https://github.com/clear-code/redmine_full_text_search'
   author_url 'https://github.com/clear-code'
-  # We can't use __dir__ here because ensuring plugin path is correctly registered even when symbolic links are used.
-  # For example, _dir__ and __FILE__ are the followings using `ln -s /redmine/real_path_to_plugin/ /redmine/symlink_path_to_plugin/`:
-  #   * __dir__: /redmine/real_path_to_plugin/
-  #   * __FILE__: ./symlink_path_to_plugin/init.rb
+  # We can't use __dir__ here because we ensure that plugin directory path is a path in Redmine directory
+  # even when we use a symbolic link to place this plugin into redmine/plugins/. If we don't use symbolic
+  # like like the following, we can use __dir__ here:
+  #
+  #   $ git clone https://github.com/clear-code/redmine_full_text_search.git redmine/plugins/full_text_search
+  #
+  # But __dir__ doesn't work when we use a symbolic link:
+  #
+  #  $ git clone https://github.com/clear-code/redmine_full_text_search.git
+  #  $ cd redmine/plugins
+  #  $ ln -s ../../redmine_full_text_search full_text_search
+  #
+  # In this case, __dir__ and __FILE__ are the followings:
+  #
+  #   __dir__: /tmp/redmine_full_text_search
+  #   __FILE__: ./full_text_search/init.rb
+  #
+  # Note that "/tmp/redmine_full_text_search" isn't a path in Redmine's plugin directory (redmine/plugins/).
+  # Redmine assumes that this is a patch in Redmine's plugin directory. So we need to compute this from
+  # __FILE__ not __dir__.
   directory File.dirname(File.absolute_path(__FILE__))
   settings partial: "settings/full_text_search"
 end


### PR DESCRIPTION
related: https://github.com/clear-code/redmine_full_text_search/issues/126

## Issue
CI failed because of the following error.
- ref: https://github.com/clear-code/redmine_full_text_search/actions/runs/8148567153/job/22271632024
```console
NoMethodError: undefined method `has_assets_dir?' for nil:NilClass

      if path.has_assets_dir?
             ^^^^^^^^^^^^^^^^
```

## Cause
```ruby
p.path = PluginLoader.directories.find {|d| d.to_s == p.directory}
```
ref: https://github.com/redmine/redmine/blob/fb449c77bc76b3bae9b3f0bfe18560b11f00902c/lib/redmine/plugin.rb#L107

The registered plugin path refers to the resolved path using a [symbolic link](https://github.com/clear-code/redmine_full_text_search/blob/0794bdb72062f7489b1c1715eba68520f13db90e/.github/workflows/test.yml#L136).
So the plugin path that Redmine gathers by `PluginLoaders` mismatches with the registered plugin path like the following.
Then the result of the above code is nil.
```ruby
PluginLoader.directories
=> 
[#<Redmine::PluginPath:0x00007f2b501b8578
  @assets_dir="/home/runner/work/redmine_full_text_search/redmine/plugins/full_text_search/assets",
  @dir="/home/runner/work/redmine_full_text_search/redmine/plugins/full_text_search", # <= This is unresolved path.
  @initializer="/home/runner/work/redmine_full_text_search/redmine/plugins/full_text_search/init.rb">]
> p.directory
=> "/home/runner/work/redmine_full_text_search/redmine_full_text_search" # <= This is resolved path.
```

## Solution
Use the path in Redmine's plugins directory for this plugin's directory just in case you use a symbolic link to set this plugin under Redmine's `plugins/`.