### PR TITLE
Use ApplicationRecord for Redmine 6 or later

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,5 @@
 # For backward compatibility with Redmine < 6.
-# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine > 6.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine >= 6.
 # ref: https://www.redmine.org/issues/38975
 unless defined?(ApplicationRecord)
   ApplicationRecord = ActiveRecord::Base

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,8 +1,6 @@
-# For backward compatibility with Redmine <= v5.x.
-# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine > 5.x
+# For backward compatibility with Redmine < 6.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine > 6.
 # ref: https://www.redmine.org/issues/38975
 unless defined?(ApplicationRecord)
-  class ApplicationRecord < ActiveRecord::Base
-    self.abstract_class = true
-  end
+  ApplicationRecord = ActiveRecord::Base
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,8 @@
+# For backward compatibility with Redmine <= v5.x.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine > 5.x
+# ref: https://www.redmine.org/issues/38975
+unless defined?(ApplicationRecord)
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/app/models/fts_query_expansion.rb
+++ b/app/models/fts_query_expansion.rb
@@ -1,4 +1,4 @@
-class FtsQueryExpansion < ActiveRecord::Base
+class FtsQueryExpansion < ApplicationRecord
   if respond_to?(:connection_db_config)
     adapter = connection_db_config.adapter
   else

--- a/app/models/full_text_search/issue_content.rb
+++ b/app/models/full_text_search/issue_content.rb
@@ -1,4 +1,4 @@
 module FullTextSearch
-  class IssueContent < ActiveRecord::Base
+  class IssueContent < ApplicationRecord
   end
 end

--- a/app/models/full_text_search/tag.rb
+++ b/app/models/full_text_search/tag.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Tag < ActiveRecord::Base
+  class Tag < ApplicationRecord
     self.table_name = :fts_tags
     belongs_to :type, class_name: "FullTextSearch::TagType"
 

--- a/app/models/full_text_search/tag_type.rb
+++ b/app/models/full_text_search/tag_type.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class TagType < ActiveRecord::Base
+  class TagType < ApplicationRecord
     self.table_name = :fts_tag_types
     has_many :tags, foreign_key: "type_id"
 

--- a/app/models/full_text_search/target.rb
+++ b/app/models/full_text_search/target.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Target < ActiveRecord::Base
+  class Target < ApplicationRecord
     self.table_name = :fts_targets
 
     if respond_to?(:connection_db_config)

--- a/app/models/full_text_search/type.rb
+++ b/app/models/full_text_search/type.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  class Type < ActiveRecord::Base
+  class Type < ApplicationRecord
     self.table_name = :fts_types
 
     class << self


### PR DESCRIPTION
Related: https://github.com/clear-code/redmine_full_text_search/issues/126

## Issue
CI failed because of the following error.
```console
Error:
FullTextSearch::SearchControllerTest::AttachmentTest#test_api:
NoMethodError: undefined method `acts_as_event' for FullTextSearch::Target:Class
```
ref: https://github.com/clear-code/redmine_full_text_search/actions/runs/8164642884/job/22320305058

## Cause
`Redmine::Acts::Event` isn't included in `ActiveRecord::Base` anymore. That's the reason we cannot use `Redmine::Acts::Event#acts_as_event`.

Before Redmine v5.1, `ActiveRecord::Base` included `Redmine::Acts::Event`. And `ActiveRecord::Base` was a base class.

https://github.com/redmine/redmine/blob/ed7873a4c49d9209c597378dab9a982391093c32/lib/plugins/acts_as_event/init.rb#L4

After Redmine master, `ApplicationRecord` included `Redmine::Acts::Event`. And `ApplicationRecord` was a base class.

https://github.com/redmine/redmine/blob/fb449c77bc76b3bae9b3f0bfe18560b11f00902c/lib/plugins/acts_as_event/init.rb#L22

## Solution
Change the base class from ActiveRecord::Base to ApplicationRecord.