### PR TITLE
ActiveSupport::TestCase.fixture_path will be deprecated from Rails v7.1

### DIFF
--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -104,7 +104,12 @@ module FullTextSearch
     def fixture_file_path(name)
       dir = File.dirname(__FILE__)
       path = Pathname(File.join(dir, "..", "..", "files", name)).expand_path
-      fixture_path = Pathname(self.class.fixture_path)
+      fixture_path = if self.class.respond_to?(:fixture_paths=)
+                       # For Rails >= 7.1
+                       Pathname(self.class.fixture_paths.first)
+                     else
+                       Pathname(self.class.fixture_path)
+                     end
       fixture_path += "files" if Rails::VERSION::MAJOR >= 6
       path.relative_path_from(fixture_path)
     end

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -102,13 +102,7 @@ module FullTextSearch
     end
 
     def fixture_file_path(name)
-      dir = File.dirname(__FILE__)
-      path = Pathname(File.join(dir, "..", "..", "files", name)).expand_path
-      return path if Rails::VERSION::MAJOR >= 7
-
-      fixture_path = Pathname(self.class.fixture_path)
-      fixture_path += "files" if Rails::VERSION::MAJOR >= 6
-      path.relative_path_from(fixture_path)
+      Pathname(File.join(File.dirname(__FILE__), "..", "..", "files", name)).expand_path
     end
 
     def capture_log

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -102,7 +102,7 @@ module FullTextSearch
     end
 
     def fixture_file_path(name)
-      Pathname(File.join(File.dirname(__FILE__), "..", "..", "files", name)).expand_path
+      File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "files", name))
     end
 
     def capture_log

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -104,12 +104,9 @@ module FullTextSearch
     def fixture_file_path(name)
       dir = File.dirname(__FILE__)
       path = Pathname(File.join(dir, "..", "..", "files", name)).expand_path
-      fixture_path = if self.class.respond_to?(:fixture_paths=)
-                       # For Rails >= 7.1
-                       Pathname(self.class.fixture_paths.first)
-                     else
-                       Pathname(self.class.fixture_path)
-                     end
+      return path if Rails::VERSION::MAJOR >= 7
+
+      fixture_path = Pathname(self.class.fixture_path)
       fixture_path += "files" if Rails::VERSION::MAJOR >= 6
       path.relative_path_from(fixture_path)
     end


### PR DESCRIPTION
Related: https://github.com/clear-code/redmine_full_text_search/issues/126

## Issue
This PR wants to solve the following `DEPRECATION WARNING`.
```
DEPRECATION WARNING: TestFixtures.fixture_path is deprecated and will be removed in Rails 7.2. Use .fixture_paths instead.
If multiple fixture paths have been configured with .fixture_paths, then .fixture_path will just return
the first path.
```

## Cause
`TestFixtures#fixture_path` will be replaced with `TestFixtures#fixture_paths` in Rails 7.1.
`TestFixtures#fixture_paths` returns the array.

Please check the following PRs.
- https://github.com/rails/rails/pull/47675
- https://github.com/rails/rails/pull/47764

## How to solve
Changed the implementation of the `AttachmentExtractTest#fixture_file_path` without using `TestFixtures#fixture_path`

- Previously, it used `TestFixtures#fixture_path` to create a relative path.
- This relative path was passed for` ActionDispatch::TestProcess::FixtureFile#fixture_file_upload`.
- Now, `ActionDispatch::TestProcess::FixtureFile#fixture_file_upload` can use absolute paths.
- Therefore, creating a relative path with `TestFixtures#fixture_path` is no longer necessary.

refs
- Rails v5.2(Redmine v4.2): [ActionDispatch::TestProcess::FixtureFile#fixture_file_upload](https://github.com/rails/rails/blob/5-2-stable/actionpack/lib/action_dispatch/testing/test_process.rb)
- Rails v6.1(Redmine v5.0 and v5.1): [ActionDispatch::TestProcess::FixtureFile#fixture_file_upload](https://github.com/rails/rails/blob/6-1-stable/actionpack/lib/action_dispatch/testing/test_process.rb)
- Rails v7.1(Redmine master): [ActionDispatch::TestProcess::FixtureFile#fixture_file_upload](https://github.com/rails/rails/blob/7-1-stable/actionpack/lib/action_dispatch/testing/test_process.rb)