### PR TITLE
Change the path passed to ChupaText to pathname

### DIFF
--- a/lib/full_text_search/attachment_mapper.rb
+++ b/lib/full_text_search/attachment_mapper.rb
@@ -109,7 +109,7 @@ JOIN projects
         else
           input = nil
         end
-        extractor.extract(disk_path, input, content_type)
+        extractor.extract(Pathname(disk_path), input, content_type)
       end
       set_extracted_content(fts_target,
                             content,

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -161,7 +161,7 @@ module FullTextSearch
         content_type: content_type,
       }
       error_message = "ChupaText::EncryptedError: " +
-                      "Encrypted data: <#{attachment.diskfile}>(#{content_type})"
+                      "Encrypted data: <file://#{attachment.diskfile}>(#{content_type})"
       assert_equal([
                      [
                        :error,


### PR DESCRIPTION
For example:
```
ChupaText::InputData.new("C:\\\\Users\\work\\redmine/bin/rails")
C:/Ruby31-x64/lib/ruby/3.1.0/uri/rfc3986_parser.rb:66:in `split': bad URI(is not URI?): "C:\\\\Users\\work\\redmine/bin/rails" (URI::InvalidURIError)
```

After change:
```
ChupaText::InputData.new(Pathname("C:\\\\Users\\work\\redmine/bin/rails"))
（success）
```