### PR TITLE
wiki_page_mapper: Add Wiki Extensions plugin tags to fts_target.tag_ids

### DIFF
--- a/lib/full_text_search/wiki_page_mapper.rb
+++ b/lib/full_text_search/wiki_page_mapper.rb
@@ -35,10 +35,18 @@ module FullTextSearch
       else
         fts_target.content = nil
       end
-      fts_target.tag_ids = tag_ids
+      fts_target.tag_ids = tag_ids | plugin_wiki_extensions_tag_ids
       fts_target.last_modified_at = @record.updated_on
       fts_target.registered_at = @record.created_on
       fts_target.save!
+    end
+
+    private
+    def plugin_wiki_extensions_tag_ids
+      return [] unless @record.respond_to?(:wiki_ext_tags)
+      @record.wiki_ext_tags.collect do |tag|
+        Tag.label(tag.name).id
+      end
     end
   end
 


### PR DESCRIPTION
Wiki Extensions plugin tags also enable synchronization in `full_text_search:synchronize`.