### PR TITLE
Support for multiple types of `FullTextSearch::Type.available?()` arguments

### DIFF
--- a/app/models/full_text_search/type.rb
+++ b/app/models/full_text_search/type.rb
@@ -3,21 +3,25 @@ module FullTextSearch
     self.table_name = :fts_types
 
     class << self
-      def [](key)
+      def normalize_key(key)
         case key
         when Class
-          __send__(key.name.underscore)
+          key.name.underscore
         when ActiveRecord::Base
-          __send__(key.class.name.underscore)
+          key.class.name.underscore
         when /\A[A-Z]/
-          __send__(key.underscore)
+          key.underscore
         else
-          __send__(key.singularize)
+          key.singularize
         end
       end
 
+      def [](key)
+        __send__(normalize_key(key))
+      end
+
       def available?(name)
-        respond_to?(name.singularize)
+        respond_to?(normalize_key(name))
       end
 
       def attachment

--- a/app/models/full_text_search/type.rb
+++ b/app/models/full_text_search/type.rb
@@ -3,7 +3,7 @@ module FullTextSearch
     self.table_name = :fts_types
 
     class << self
-      def normalize_key(key)
+      private def normalize_key(key)
         case key
         when Class
           key.name.underscore


### PR DESCRIPTION
Match the arguments of `[](key)`.

It can be used as follows:

```
irb(main):001:0> FullTextSearch::Type.available?('wiki_page')
=> true
irb(main):002:0> FullTextSearch::Type.available?('WikiPage')
=> true
```