### PR TITLE
attachment_mapper: Skip for unknown container_type

### DIFF
--- a/lib/full_text_search/attachment_mapper.rb
+++ b/lib/full_text_search/attachment_mapper.rb
@@ -54,6 +54,7 @@ JOIN projects
     def upsert_fts_target(options={})
       # container is not specified when initial upload
       return if @record.container_type.nil?
+      return unless Type.available?(@record.container_type)
 
       fts_target = find_fts_target
       fts_target.source_id = @record.id


### PR DESCRIPTION
`Attachment` may be used by plugins.
At that time, an unknown value is set to `container_type`.

In this case, skip it because the upsert will fail with an error.