### PR TITLE
PluginWikiExtensionsTagSearchable: Skip if no FullTextSearch::Target for the target WikiPage

### DIFF
--- a/lib/full_text_search/plugin_wiki_extensions_tag_searchable.rb
+++ b/lib/full_text_search/plugin_wiki_extensions_tag_searchable.rb
@@ -24,12 +24,14 @@ module FullTextSearch
 
     def fts_after_create
       fts_target = find_fts_target
+      return unless fts_target
       fts_target.tag_ids |= [find_fts_tag_label_id]
       fts_target.save!
     end
 
     def fts_after_destroy
       fts_target = find_fts_target
+      return unless fts_target
       fts_target.tag_ids -= [find_fts_tag_label_id]
       fts_target.save!
     end


### PR DESCRIPTION
This can occur when WikiPage data is imported asynchronously.