### PR TITLE
test: update test cases depending on updated Git repository data

### DIFF
--- a/test/unit/full_text_search/change_git_test.rb
+++ b/test/unit/full_text_search/change_git_test.rb
@@ -29,107 +29,53 @@ module FullTextSearch
                         container_type_id: Type.repository.id).
                   order(source_id: :asc)
       first_change = Change.find_by!(path: "images/edit.png")
-      # Redmine master over v5.2 uses the updated Git repository test data.
-      if Gem::Version.new(Redmine::VERSION.to_s) < Gem::Version.new("5.2") &&
-         Redmine::VERSION::BRANCH != "devel"
-        first_change = Change.find_by!(path: "images/edit.png")
-        last_change = Change.where(path: "issue-8857/test01.txt").last
-        expected_titles = [
-          "images/edit.png",
-          "copied_README",
-          "new_file.txt",
-          "renamed_test.txt",
-          "sources/watchers_controller.rb",
-          "this_is_a_really_long_and_verbose_directory_name/this_is_because_of_a_simple_reason/it_is_testing_the_ability_of_redmine_to_use_really_long_path_names/These_names_exceed_255_chars_in_total/That_is_the_single_reason_why_we_have_this_directory_here/But_there_might_also_be_additonal_reasons/And_then_there_is_not_even_somthing_funny_in_here.txt",
-          "filemane with spaces.txt",
-          " filename with a leading space.txt ",
-          "latin-1/test00.txt",
-          "README",
-          "latin-1-dir/make-latin-1-file.rb",
-          "issue-8857/test00.txt",
-          "issue-8857/test01.txt",
-        ]
-        expected_first_change = {
-          "project_id" => @project.id,
-          "source_id" => first_change.id,
-          "source_type_id" => Type.change.id,
-          "last_modified_at" => parse_time("2007-12-14T09:24:01Z"),
-          "registered_at" => parse_time("2007-12-14T09:24:01Z"),
-          "container_id" => repository.id,
-          "container_type_id" => Type.repository.id,
-          "title" => "images/edit.png",
-          "content" => "",
-          "custom_field_id" => null_number,
-          "is_private" => null_boolean,
-          "tag_ids" => [Tag.extension("png").id],
-        }
-        expected_last_change = {
-          "project_id" => @project.id,
-          "source_id" => last_change.id,
-          "source_type_id" => Type.change.id,
-          "last_modified_at" => parse_time("2011-01-01T03:00:00Z"),
-          "registered_at" => parse_time("2011-01-01T03:00:00Z"),
-          "container_id" => repository.id,
-          "container_type_id" => Type.repository.id,
-          "custom_field_id" => null_number,
-          "title" => "issue-8857/test01.txt",
-          "content" => <<-CONTENT,
+      last_change = Change.where(path: "issue-8857/test01.txt").last
+      expected_titles = [
+        "images/edit.png",
+        "copied_README",
+        "renamed_test.txt",
+        "sources/watchers_controller.rb",
+        "this_is_a_really_long_and_verbose_directory_name/this_is_because_of_a_simple_reason/it_is_testing_the_ability_of_redmine_to_use_really_long_path_names/These_names_exceed_255_chars_in_total/That_is_the_single_reason_why_we_have_this_directory_here/But_there_might_also_be_additonal_reasons/And_then_there_is_not_even_somthing_funny_in_here.txt",
+        "filemane with spaces.txt",
+        " filename with a leading space.txt ",
+        "new_file.txt",
+        "latin-1/test00.txt",
+        "README",
+        "latin-1-dir/make-latin-1-file.rb",
+        "issue-8857/test00.txt",
+        "issue-8857/test01.txt",
+      ]
+      expected_first_change = {
+        "project_id" => @project.id,
+        "source_id" => first_change.id,
+        "source_type_id" => Type.change.id,
+        "last_modified_at" => parse_time("2007-12-14T09:24:01Z"),
+        "registered_at" => parse_time("2007-12-14T09:24:01Z"),
+        "container_id" => repository.id,
+        "container_type_id" => Type.repository.id,
+        "title" => "images/edit.png",
+        "content" => "",
+        "custom_field_id" => null_number,
+        "is_private" => null_boolean,
+        "tag_ids" => [Tag.extension("png").id],
+      }
+      expected_last_change = {
+        "project_id" => @project.id,
+        "source_id" => last_change.id,
+        "source_type_id" => Type.change.id,
+        "last_modified_at" => parse_time("2011-01-01T03:00:00Z"),
+        "registered_at" => parse_time("2011-01-01T03:00:00Z"),
+        "container_id" => repository.id,
+        "container_type_id" => Type.repository.id,
+        "custom_field_id" => null_number,
+        "title" => "issue-8857/test01.txt",
+        "content" => <<-CONTENT,
 test
 test
-          CONTENT
-          "is_private" => null_boolean,
-          "tag_ids" => [Tag.extension("txt").id],
-        }
-      else
-        first_change = Change.find_by!(path: "images/edit.png")
-        last_change = Change.where(path: "issue-8857/test01.txt").last
-        expected_titles = [
-          "images/edit.png",
-          "copied_README",
-          "renamed_test.txt",
-          "sources/watchers_controller.rb",
-          "this_is_a_really_long_and_verbose_directory_name/this_is_because_of_a_simple_reason/it_is_testing_the_ability_of_redmine_to_use_really_long_path_names/These_names_exceed_255_chars_in_total/That_is_the_single_reason_why_we_have_this_directory_here/But_there_might_also_be_additonal_reasons/And_then_there_is_not_even_somthing_funny_in_here.txt",
-          "filemane with spaces.txt",
-          " filename with a leading space.txt ",
-          "new_file.txt",
-          "latin-1/test00.txt",
-          "README",
-          "latin-1-dir/make-latin-1-file.rb",
-          "issue-8857/test00.txt",
-          "issue-8857/test01.txt",
-        ]
-        expected_first_change = {
-          "project_id" => @project.id,
-          "source_id" => first_change.id,
-          "source_type_id" => Type.change.id,
-          "last_modified_at" => parse_time("2007-12-14T09:24:01Z"),
-          "registered_at" => parse_time("2007-12-14T09:24:01Z"),
-          "container_id" => repository.id,
-          "container_type_id" => Type.repository.id,
-          "title" => "images/edit.png",
-          "content" => "",
-          "custom_field_id" => null_number,
-          "is_private" => null_boolean,
-          "tag_ids" => [Tag.extension("png").id],
-        }
-        expected_last_change = {
-          "project_id" => @project.id,
-          "source_id" => last_change.id,
-          "source_type_id" => Type.change.id,
-          "last_modified_at" => parse_time("2011-01-01T03:00:00Z"),
-          "registered_at" => parse_time("2011-01-01T03:00:00Z"),
-          "container_id" => repository.id,
-          "container_type_id" => Type.repository.id,
-          "custom_field_id" => null_number,
-          "title" => "issue-8857/test01.txt",
-          "content" => <<-CONTENT,
-test
-test
-          CONTENT
-          "is_private" => null_boolean,
-          "tag_ids" => [Tag.extension("txt").id],
-        }
-      end
+        CONTENT
+        "is_private" => null_boolean,
+        "tag_ids" => [Tag.extension("txt").id],
+      }
       assert_equal([
                      expected_titles,
                      expected_first_change,


### PR DESCRIPTION
Related PR: GH-157

We don't have to consider the differences between Redmine versions and removed related codes.
Because the updated Git repository's test are reflected to the other versions as follows.

- Redmine 5.1-stable: https://github.com/redmine/redmine/commit/e7980d7f4c3574a12b3918910f6de837111afd4b
- Redmine 5.0-stabl: https://github.com/redmine/redmine/commit/39a53b85d95c0069bb4aff1acaed111325008291