### PR TITLE
markup_parser: skip parsing HTML content when it is empty

### DIFF
--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -15,11 +15,10 @@ module FullTextSearch
       html = with_user(User.admin.first) do
         textilizable(object, attribute, options)
       end
+      return ["", []] unless html.present?
       document = Document.new
-      if html.presence
-        parser = Nokogiri::HTML::SAX::Parser.new(document)
-        parser.parse(html)
-      end
+      parser = Nokogiri::HTML::SAX::Parser.new(document)
+      parser.parse(html)
       [document.text.strip, document.tag_ids]
     end
 

--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -16,6 +16,7 @@ module FullTextSearch
         textilizable(object, attribute, options)
       end
       return ["", []] unless html.present?
+
       document = Document.new
       parser = Nokogiri::HTML::SAX::Parser.new(document)
       parser.parse(html)

--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -16,8 +16,10 @@ module FullTextSearch
         textilizable(object, attribute, options)
       end
       document = Document.new
-      parser = Nokogiri::HTML::SAX::Parser.new(document)
-      parser.parse(html)
+      if html.presence
+        parser = Nokogiri::HTML::SAX::Parser.new(document)
+        parser.parse(html)
+      end
       [document.text.strip, document.tag_ids]
     end
 


### PR DESCRIPTION
## Issue

This PR resolves the following CI error.

```
Error:
FullTextSearch::BatchRunnerSynchronizeTest#test_archived_changeset:
RuntimeError: input string cannot be empty
    plugins/full_text_search/lib/full_text_search/markup_parser.rb:20:in `parse'
    plugins/full_text_search/lib/full_text_search/issue_mapper.rb:25:in `upsert_fts_target'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:129:in `block (2 levels) in synchronize_fts_targets_internal'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:335:in `each'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:335:in `each'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:335:in `iterate'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:121:in `block in synchronize_fts_targets_internal'
    plugins/full_text_search/lib/full_text_search/resolver.rb:43:in `each'
    plugins/full_text_search/lib/full_text_search/resolver.rb:43:in `each'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:116:in `synchronize_fts_targets_internal'
    plugins/full_text_search/lib/full_text_search/batch_runner.rb:12:in `synchronize'
    plugins/full_text_search/test/unit/full_text_search/batch_runner_synchronize_test.rb:34:in `setup'

bin/rails test plugins/full_text_search/test/unit/full_text_search/batch_runner_synchronize_test.rb:219
```

## Cause

The error occurs because Nokogiri's behavior for handling an empty string changed in version 1.17.0.

- Before 1.17.0: `Nokogiri::HTML::SAX::Parser#parse` returned `nil` when passed an empty string.
- After 1.17.0: `Nokogiri::HTML::SAX::Parser#parse` raises a `RuntimeError` when passed an empty string.

Refer to the following Nokogiri commit for details: https://github.com/sparklemotion/nokogiri/commit/35596e7d747c9823fcecf55a05c210f72aa97bf2

## Solution

Skip parsing the HTML content when it is empty by adding a presence check.