### PR TITLE
ci: Install subversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,9 +119,10 @@ jobs:
           esac
       - name: Install dependencies
         run: |
+          sudo apt update
+          sudo apt install -y subversion
           case ${RDBMS} in
             postgresql)
-              sudo apt update
               sudo apt install -y postgresql-client
               ;;
           esac


### PR DESCRIPTION
The following command executed by CI fails:
```
svnadmin create tmp/test/subversion_repository
zcat test/fixtures/repositories/subversion_repository.dump.gz | \
  svnadmin load tmp/test/subversion_repository
```

Error:
```
svnadmin: command not found
```

It seems that it is no longer installed by default in Ubuntu 24.