### PR TITLE
jobs/update_issue_content: add issue attachment's info to content

### DIFF
--- a/app/jobs/full_text_search/update_issue_content_job.rb
+++ b/app/jobs/full_text_search/update_issue_content_job.rb
@@ -52,14 +52,13 @@ module FullTextSearch
                 .reject {|j| j.notes.blank? || excludes.include?(j.id) }
                 .sort_by(&:id)
                 .map(&:notes)
-      attachment_contents = issue.attachments
-                              .order(:id)
-                              .reject {|a| excludes.include?(a.id) }
-                              .collect {|a| [a.filename, a.description] }
-                              .flatten
-                              .compact
       content.concat(notes)
-      content.concat(attachment_contents)
+      issue.attachments.order(:id)
+                       .reject {|a| excludes.include?(a.id) }
+                       .each do |attachment|
+        content << attachment.filename if attachment.filename.present?
+        content << attachment.description if attachment.description.present?
+      end
       content.join("\n")
     end
   end

--- a/app/jobs/full_text_search/update_issue_content_job.rb
+++ b/app/jobs/full_text_search/update_issue_content_job.rb
@@ -39,7 +39,7 @@ module FullTextSearch
           issue_id = options[:issue_id]
           FullTextSearch::IssueContent
             .where(issue_id: issue_id)
-            .update_all(content: create_content(issue_id, excludes: [record_id]))
+            .update_all(content: create_content(issue_id))
         end
       end
     end
@@ -53,9 +53,7 @@ module FullTextSearch
                 .sort_by(&:id)
                 .map(&:notes)
       content.concat(notes)
-      issue.attachments.order(:id)
-                       .reject {|a| excludes.include?(a.id) }
-                       .each do |attachment|
+      issue.attachments.order(:id).each do |attachment|
         content << attachment.filename if attachment.filename.present?
         content << attachment.description if attachment.description.present?
       end

--- a/app/jobs/full_text_search/update_issue_content_job.rb
+++ b/app/jobs/full_text_search/update_issue_content_job.rb
@@ -35,6 +35,11 @@ module FullTextSearch
           FullTextSearch::IssueContent
             .where(issue_id: issue_id)
             .update_all(content: create_content(issue_id, excludes: [record_id]))
+        when "Attachment"
+          issue_id = options[:issue_id]
+          FullTextSearch::IssueContent
+            .where(issue_id: issue_id)
+            .update_all(content: create_content(issue_id, excludes: [record_id]))
         end
       end
     end
@@ -47,7 +52,14 @@ module FullTextSearch
                 .reject {|j| j.notes.blank? || excludes.include?(j.id) }
                 .sort_by(&:id)
                 .map(&:notes)
+      attachment_contents = issue.attachments
+                              .order(:id)
+                              .reject {|a| excludes.include?(a.id) }
+                              .collect {|a| [a.filename, a.description] }
+                              .flatten
+                              .compact
       content.concat(notes)
+      content.concat(attachment_contents)
       content.join("\n")
     end
   end

--- a/init.rb
+++ b/init.rb
@@ -81,9 +81,10 @@ FullTextSearch.resolver.each do |redmine_class, mapper_class|
   mapper_class.attach(redmine_class)
 end
 FullTextSearch::CustomFieldCallbacks.attach
-Attachment.include(FullTextSearch::SimilarSearcher::Model)
+Attachment.include(FullTextSearch::IssueContentSynchronizable)
+Issue.include(FullTextSearch::IssueContentSynchronizable)
 Issue.include(FullTextSearch::SimilarSearcher::Model)
-Journal.include(FullTextSearch::SimilarSearcher::Model)
+Journal.include(FullTextSearch::IssueContentSynchronizable)
 SearchController.helper(FullTextSearch::Hooks::SearchHelper)
 SearchController.prepend(FullTextSearch::Hooks::ControllerSearchIndex)
 IssuesController.helper(FullTextSearch::Hooks::SimilarIssuesHelper)

--- a/init.rb
+++ b/init.rb
@@ -81,10 +81,10 @@ FullTextSearch.resolver.each do |redmine_class, mapper_class|
   mapper_class.attach(redmine_class)
 end
 FullTextSearch::CustomFieldCallbacks.attach
-Attachment.include(FullTextSearch::IssueContentSynchronizable)
-Issue.include(FullTextSearch::IssueContentSynchronizable)
+Attachment.include(FullTextSearch::AttachmentSynchronizable)
+Issue.include(FullTextSearch::IssueSynchronizable)
 Issue.include(FullTextSearch::SimilarSearcher::Model)
-Journal.include(FullTextSearch::IssueContentSynchronizable)
+Journal.include(FullTextSearch::JournalSynchronizable)
 SearchController.helper(FullTextSearch::Hooks::SearchHelper)
 SearchController.prepend(FullTextSearch::Hooks::ControllerSearchIndex)
 IssuesController.helper(FullTextSearch::Hooks::SimilarIssuesHelper)

--- a/init.rb
+++ b/init.rb
@@ -81,6 +81,7 @@ FullTextSearch.resolver.each do |redmine_class, mapper_class|
   mapper_class.attach(redmine_class)
 end
 FullTextSearch::CustomFieldCallbacks.attach
+Attachment.include(FullTextSearch::SimilarSearcher::Model)
 Issue.include(FullTextSearch::SimilarSearcher::Model)
 Journal.include(FullTextSearch::SimilarSearcher::Model)
 SearchController.helper(FullTextSearch::Hooks::SearchHelper)

--- a/lib/full_text_search/attachment_synchronizable.rb
+++ b/lib/full_text_search/attachment_synchronizable.rb
@@ -1,0 +1,30 @@
+module FullTextSearch
+  module AttachmentSynchronizable
+    extend ActiveSupport::Concern
+
+    included do
+      after_commit :queue_sync_on_commit
+      after_destroy :queue_sync_on_destroy
+    end
+
+    private
+
+    def queue_sync(action, options = {})
+      FullTextSearch::UpdateIssueContentJob.perform_later(
+        self.class.name,
+        self.id,
+        action,
+        options
+      )
+    end
+
+    def queue_sync_on_commit
+      queue_sync("commit")
+    end
+
+    def queue_sync_on_destroy
+      return if self.container_type != Issue.name
+      queue_sync("destroy", issue_id: self.container_id)
+    end
+  end
+end

--- a/lib/full_text_search/attachment_synchronizable.rb
+++ b/lib/full_text_search/attachment_synchronizable.rb
@@ -12,7 +12,7 @@ module FullTextSearch
     def queue_sync(action, options = {})
       FullTextSearch::UpdateIssueContentJob.perform_later(
         self.class.name,
-        self.id,
+        id,
         action,
         options
       )
@@ -23,8 +23,8 @@ module FullTextSearch
     end
 
     def queue_sync_on_destroy
-      return if self.container_type != Issue.name
-      queue_sync("destroy", issue_id: self.container_id)
+      return if container_type != Issue.name
+      queue_sync("destroy", issue_id: container_id)
     end
   end
 end

--- a/lib/full_text_search/issue_content_synchronizable.rb
+++ b/lib/full_text_search/issue_content_synchronizable.rb
@@ -1,0 +1,38 @@
+module FullTextSearch
+  module IssueContentSynchronizable
+    extend ActiveSupport::Concern
+
+    included do
+      after_commit :queue_sync_on_commit
+      after_destroy :queue_sync_on_destroy
+    end
+
+    private
+
+    def queue_sync(action, options = {})
+      FullTextSearch::UpdateIssueContentJob.perform_later(
+        self.class.name,
+        self.id,
+        action,
+        options
+      )
+    end
+
+    def queue_sync_on_commit
+      queue_sync("commit")
+    end
+
+    def queue_sync_on_destroy
+      case self
+      when Issue
+        queue_sync("destroy")
+      when Journal
+        queue_sync("destroy", issue_id: self.journalized_id)
+      when Attachment
+        if self.container_type == Issue.name
+          queue_sync("destroy", issue_id: self.container_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/full_text_search/issue_synchronizable.rb
+++ b/lib/full_text_search/issue_synchronizable.rb
@@ -1,0 +1,29 @@
+module FullTextSearch
+  module IssueSynchronizable
+    extend ActiveSupport::Concern
+
+    included do
+      after_commit :queue_sync_on_commit
+      after_destroy :queue_sync_on_destroy
+    end
+
+    private
+
+    def queue_sync(action, options = {})
+      FullTextSearch::UpdateIssueContentJob.perform_later(
+        self.class.name,
+        self.id,
+        action,
+        options
+      )
+    end
+
+    def queue_sync_on_commit
+      queue_sync("commit")
+    end
+
+    def queue_sync_on_destroy
+      queue_sync("destroy")
+    end
+  end
+end

--- a/lib/full_text_search/issue_synchronizable.rb
+++ b/lib/full_text_search/issue_synchronizable.rb
@@ -9,12 +9,11 @@ module FullTextSearch
 
     private
 
-    def queue_sync(action, options = {})
+    def queue_sync(action)
       FullTextSearch::UpdateIssueContentJob.perform_later(
         self.class.name,
         id,
-        action,
-        options
+        action
       )
     end
 

--- a/lib/full_text_search/issue_synchronizable.rb
+++ b/lib/full_text_search/issue_synchronizable.rb
@@ -12,7 +12,7 @@ module FullTextSearch
     def queue_sync(action, options = {})
       FullTextSearch::UpdateIssueContentJob.perform_later(
         self.class.name,
-        self.id,
+        id,
         action,
         options
       )

--- a/lib/full_text_search/journal_synchronizable.rb
+++ b/lib/full_text_search/journal_synchronizable.rb
@@ -1,5 +1,5 @@
 module FullTextSearch
-  module IssueContentSynchronizable
+  module JournalSynchronizable
     extend ActiveSupport::Concern
 
     included do
@@ -23,16 +23,7 @@ module FullTextSearch
     end
 
     def queue_sync_on_destroy
-      case self
-      when Issue
-        queue_sync("destroy")
-      when Journal
-        queue_sync("destroy", issue_id: self.journalized_id)
-      when Attachment
-        if self.container_type == Issue.name
-          queue_sync("destroy", issue_id: self.container_id)
-        end
-      end
+      queue_sync("destroy", issue_id: self.journalized_id)
     end
   end
 end

--- a/lib/full_text_search/journal_synchronizable.rb
+++ b/lib/full_text_search/journal_synchronizable.rb
@@ -12,7 +12,7 @@ module FullTextSearch
     def queue_sync(action, options = {})
       FullTextSearch::UpdateIssueContentJob.perform_later(
         self.class.name,
-        self.id,
+        id,
         action,
         options
       )
@@ -23,7 +23,7 @@ module FullTextSearch
     end
 
     def queue_sync_on_destroy
-      queue_sync("destroy", issue_id: self.journalized_id)
+      queue_sync("destroy", issue_id: journalized_id)
     end
   end
 end

--- a/lib/full_text_search/similar_searcher.rb
+++ b/lib/full_text_search/similar_searcher.rb
@@ -31,15 +31,15 @@ module FullTextSearch
           end
         end
 
-        def similar_query
-          query = [subject, description]
+        def similar_term
+          terms = [subject, description]
           notes = journals.sort_by(&:id).map(&:notes)
-          query.concat(notes)
+          terms.concat(notes)
           attachments.order(:id).each do |attachment|
-            query << attachment.filename if attachment.filename.present?
-            query << attachment.description if attachment.description.present?
+            terms << attachment.filename if attachment.filename.present?
+            terms << attachment.description if attachment.description.present?
           end
-          query.join("\n")
+          terms.join("\n")
         end
       end
     end

--- a/lib/full_text_search/similar_searcher.rb
+++ b/lib/full_text_search/similar_searcher.rb
@@ -3,10 +3,6 @@ module FullTextSearch
     module Model
       def self.included(base)
         base.include(InstanceMethods)
-        base.class_eval do
-          after_commit Callbacks
-          after_destroy Callbacks
-        end
         if base.respond_to?(:connection_db_config)
           adapter = base.connection_db_config.adapter
         else
@@ -44,42 +40,6 @@ module FullTextSearch
             query << attachment.description if attachment.description.present?
           end
           query.join("\n")
-        end
-      end
-
-      # Add callbacks to Issue
-      class Callbacks
-        class << self
-          def after_commit(record)
-            FullTextSearch::UpdateIssueContentJob
-              .perform_later(record.class.name,
-                             record.id,
-                             "commit")
-          end
-
-          def after_destroy(record)
-            # TODO: Refine
-            case record
-            when Issue
-              FullTextSearch::UpdateIssueContentJob
-                .perform_later(record.class.name,
-                               record.id,
-                               "destroy")
-            when Journal
-              FullTextSearch::UpdateIssueContentJob
-                .perform_later(record.class.name,
-                               record.id,
-                               "destroy",
-                               issue_id: record.journalized_id)
-            when Attachment
-              return unless record.container_type == Issue.name
-              FullTextSearch::UpdateIssueContentJob
-                .perform_later(record.class.name,
-                               record.id,
-                               "destroy",
-                               issue_id: record.container_id)
-            end
-          end
         end
       end
     end

--- a/lib/full_text_search/similar_searcher.rb
+++ b/lib/full_text_search/similar_searcher.rb
@@ -31,15 +31,15 @@ module FullTextSearch
           end
         end
 
-        def similar_term
-          terms = [subject, description]
+        def similar_content
+          contents = [subject, description]
           notes = journals.sort_by(&:id).map(&:notes)
-          terms.concat(notes)
+          contents.concat(notes)
           attachments.order(:id).each do |attachment|
-            terms << attachment.filename if attachment.filename.present?
-            terms << attachment.description if attachment.description.present?
+            contents << attachment.filename if attachment.filename.present?
+            contents << attachment.description if attachment.description.present?
           end
-          terms.join("\n")
+          contents.join("\n")
         end
       end
     end

--- a/lib/full_text_search/similar_searcher.rb
+++ b/lib/full_text_search/similar_searcher.rb
@@ -34,6 +34,17 @@ module FullTextSearch
             build_condition("||", conditions)
           end
         end
+
+        def similar_query
+          query = [subject, description]
+          notes = journals.sort_by(&:id).map(&:notes)
+          query.concat(notes)
+          attachments.order(:id).each do |attachment|
+            query << attachment.filename if attachment.filename.present?
+            query << attachment.description if attachment.description.present?
+          end
+          query.join("\n")
+        end
       end
 
       # Add callbacks to Issue

--- a/lib/full_text_search/similar_searcher.rb
+++ b/lib/full_text_search/similar_searcher.rb
@@ -60,6 +60,13 @@ module FullTextSearch
                                record.id,
                                "destroy",
                                issue_id: record.journalized_id)
+            when Attachment
+              return unless record.container_type == Issue.name
+              FullTextSearch::UpdateIssueContentJob
+                .perform_later(record.class.name,
+                               record.id,
+                               "destroy",
+                               issue_id: record.container_id)
             end
           end
         end

--- a/lib/full_text_search/similar_searcher/mroonga.rb
+++ b/lib/full_text_search/similar_searcher/mroonga.rb
@@ -17,14 +17,14 @@ module FullTextSearch
                    'select',
                    'table', 'issue_contents',
                    'output_columns', 'issue_id, _score',
-                   'filter', CONCAT('(content *S "', mroonga_escape(:desc), '") && issue_id != :id', ' && #{filter_condition(user, project_ids)}'),
+                   'filter', CONCAT('(content *S "', mroonga_escape(:query), '") && issue_id != :id', ' && #{filter_condition(user, project_ids)}'),
                    'limit', ':limit',
                    'sort_keys', '-_score'
                  )
           SQL
           r = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, desc: desc, id: id, limit: limit]))
+            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, query: similar_query, id: id, limit: limit]))
           end
           # NOTE: Hack to use Groonga::Client::Response.parse
           # Raise Mysql2::Error if error occurred

--- a/lib/full_text_search/similar_searcher/mroonga.rb
+++ b/lib/full_text_search/similar_searcher/mroonga.rb
@@ -29,14 +29,14 @@ module FullTextSearch
                    'select',
                    'table', 'issue_contents',
                    'output_columns', 'issue_id, _score',
-                   'filter', CONCAT('(content *S "', mroonga_escape(:term), '") && issue_id != ', :id, ' && #{filter_condition(user, project_ids)}'),
+                   'filter', CONCAT('(content *S "', mroonga_escape(:content), '") && issue_id != ', :id, ' && #{filter_condition(user, project_ids)}'),
                    'limit', :limit,
                    'sort_keys', '-_score'
                  )
           SQL
           r = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, term: similar_term, id: id.to_s, limit: limit.to_s]))
+            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, content: similar_content, id: id.to_s, limit: limit.to_s]))
           end
           # NOTE: Hack to use Groonga::Client::Response.parse
           # Raise Mysql2::Error if error occurred

--- a/lib/full_text_search/similar_searcher/mroonga.rb
+++ b/lib/full_text_search/similar_searcher/mroonga.rb
@@ -16,14 +16,14 @@ module FullTextSearch
                    'select',
                    'table', 'issue_contents',
                    'output_columns', 'issue_id, _score',
-                   'filter', CONCAT('(content *S "', mroonga_escape(:query), '") && issue_id != ', :id, ' && #{filter_condition(user, project_ids)}'),
+                   'filter', CONCAT('(content *S "', mroonga_escape(:term), '") && issue_id != ', :id, ' && #{filter_condition(user, project_ids)}'),
                    'limit', :limit,
                    'sort_keys', '-_score'
                  )
           SQL
           r = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, query: similar_query, id: id.to_s, limit: limit.to_s]))
+            r = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, term: similar_term, id: id.to_s, limit: limit.to_s]))
           end
           # NOTE: Hack to use Groonga::Client::Response.parse
           # Raise Mysql2::Error if error occurred

--- a/lib/full_text_search/similar_searcher/pgroonga.rb
+++ b/lib/full_text_search/similar_searcher/pgroonga.rb
@@ -17,7 +17,7 @@ module FullTextSearch
                    ARRAY[
                      'table', pgroonga_table_name('#{similar_issues_index_name}'),
                      'output_columns', 'issue_id, _score',
-                     'filter', '(content *S ' || pgroonga_escape(:query) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
+                     'filter', '(content *S ' || pgroonga_escape(:term) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
                      'limit', ':limit',
                      'sort_keys', '-_score'
                    ]
@@ -25,7 +25,7 @@ module FullTextSearch
           SQL
           response = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, query: similar_query, id: id, limit: limit]))
+            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, term: similar_term, id: id, limit: limit]))
           end
           command = Groonga::Command.find("select").new("select", {})
           r = Groonga::Client::Response.parse(command, response)

--- a/lib/full_text_search/similar_searcher/pgroonga.rb
+++ b/lib/full_text_search/similar_searcher/pgroonga.rb
@@ -17,7 +17,7 @@ module FullTextSearch
                    ARRAY[
                      'table', pgroonga_table_name('#{similar_issues_index_name}'),
                      'output_columns', 'issue_id, _score',
-                     'filter', '(content *S ' || pgroonga_escape(:term) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
+                     'filter', '(content *S ' || pgroonga_escape(:content) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
                      'limit', ':limit',
                      'sort_keys', '-_score'
                    ]
@@ -25,7 +25,7 @@ module FullTextSearch
           SQL
           response = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, term: similar_term, id: id, limit: limit]))
+            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, content: similar_content, id: id, limit: limit]))
           end
           command = Groonga::Command.find("select").new("select", {})
           r = Groonga::Client::Response.parse(command, response)

--- a/lib/full_text_search/similar_searcher/pgroonga.rb
+++ b/lib/full_text_search/similar_searcher/pgroonga.rb
@@ -11,14 +11,13 @@ module FullTextSearch
 
       module InstanceMethods
         def similar_issues(user: User.current, project_ids: [], limit: 5)
-          desc = [subject, description, journals.sort_by(&:id).map(&:notes)].flatten.join("\n")
           sql = <<-SQL.strip_heredoc
           select pgroonga_command(
                    'select',
                    ARRAY[
                      'table', pgroonga_table_name('#{similar_issues_index_name}'),
                      'output_columns', 'issue_id, _score',
-                     'filter', '(content *S ' || pgroonga_escape(:desc) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
+                     'filter', '(content *S ' || pgroonga_escape(:query) || ') && issue_id != :id' || ' && #{filter_condition(user, project_ids)}',
                      'limit', ':limit',
                      'sort_keys', '-_score'
                    ]
@@ -26,7 +25,7 @@ module FullTextSearch
           SQL
           response = nil
           ActiveSupport::Notifications.instrument("groonga.similar.search", sql: sql) do
-            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, desc: desc, id: id, limit: limit]))
+            response = self.class.connection.select_value(ActiveRecord::Base.send(:sanitize_sql_array, [sql, query: similar_query, id: id, limit: limit]))
           end
           command = Groonga::Command.find("select").new("select", {})
           r = Groonga::Client::Response.parse(command, response)

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -72,9 +72,9 @@ module FullTextSearch
 
     def test_same_structure_with_attachment
       set_tmp_attachments_directory
-      fts_engine_groonga_latest_file =
+      fts_engine_groonga_latest =
         Issue.generate!(project: @project, subject: "ぐるんが")
-      fts_engine_groonga_latest_file.save_attachments(
+      fts_engine_groonga_latest.save_attachments(
         {
           '1' => {
             'file' => mock_file_with_options(
@@ -82,11 +82,11 @@ module FullTextSearch
         }
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_groonga_latest_file.save!
+        fts_engine_groonga_latest.save!
       end
-      fts_engine_pgroonga_latest_file =
+      fts_engine_pgroonga_latest =
         Issue.generate!(project: @project, subject: "ぴーじーるんが")
-      fts_engine_pgroonga_latest_file.save_attachments(
+      fts_engine_pgroonga_latest.save_attachments(
         {
           '1' => {
             'file' => mock_file_with_options(
@@ -94,19 +94,19 @@ module FullTextSearch
         }
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_pgroonga_latest_file.save!
+        fts_engine_pgroonga_latest.save!
       end
       similar_issues =
-        fts_engine_groonga_latest_file
+        fts_engine_groonga_latest
           .similar_issues(project_ids: [@project.id])
-      assert_equal([fts_engine_pgroonga_latest_file],
+      assert_equal([fts_engine_pgroonga_latest],
                    similar_issues)
 
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_groonga_latest_file.attachments.first.destroy
+        fts_engine_groonga_latest.attachments.first.destroy
       end
       similar_issues =
-        fts_engine_groonga_latest_file
+        fts_engine_groonga_latest
           .reload
           .similar_issues(project_ids: [@project.id])
       assert_equal([], similar_issues)

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -5,6 +5,7 @@ module FullTextSearch
     include ActiveJob::TestHelper
 
     def setup
+      IssueContent.destroy_all
       User.current = User.find(1)
       @project = Project.generate!
       User.add_to_project(User.current, @project)
@@ -74,7 +75,7 @@ module FullTextSearch
         {
           '1' => {
             'file' => mock_file_with_options(
-              :original_filename => "Groonga 解説資料 最新版")}
+              :original_filename => "高速に検索 オープンソース! 最新情報")}
         }
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
@@ -86,7 +87,7 @@ module FullTextSearch
         {
           '1' => {
             'file' => mock_file_with_options(
-              :original_filename => "PGroonga 解説資料 最新版")}
+              :original_filename => "組み込んで高速に検索 オープンソース! 最新情報")}
         }
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -2,6 +2,8 @@ require File.expand_path("../../../test_helper", __FILE__)
 
 module FullTextSearch
   class SimilarSearchIssueTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
     def setup
       User.current = User.find(1)
       @project = Project.generate!
@@ -10,15 +12,19 @@ module FullTextSearch
 
     def test_same_structure_on_issue
       fts_engine_groonga_open_source =
-        Issue.generate!(
-          project: @project,
-          subject: "ぐるんが",
-          description: "高速に検索できます。 オープンソースです。")
+        perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+          Issue.generate!(
+            project: @project,
+            subject: "ぐるんが",
+            description: "高速に検索できます。 オープンソースです。")
+        end
       fts_engine_pgroonga_open_source =
-        Issue.generate!(
-          project: @project,
-          subject: "ぴーじーるんが",
-          description: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
+        perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+          Issue.generate!(
+            project: @project,
+            subject: "ぴーじーるんが",
+            description: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
+        end
 
       similar_issues =
         fts_engine_groonga_open_source.similar_issues(
@@ -26,7 +32,9 @@ module FullTextSearch
       assert_equal([fts_engine_pgroonga_open_source],
                    similar_issues)
 
-      fts_engine_groonga_open_source.update!(description: nil)
+      perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+        fts_engine_groonga_open_source.update!(description: nil)
+      end
       similar_issues =
         fts_engine_groonga_open_source.similar_issues(
           project_ids: [@project.id])
@@ -35,19 +43,24 @@ module FullTextSearch
 
     def test_same_structure_with_journal
       fts_engine_groonga_open_source =
-        Issue.generate!(project: @project, subject: "ぐるんが")
-             .journals.create!(notes: "高速に検索できます。 オープンソースです。")
+        perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+          Issue.generate!(project: @project, subject: "ぐるんが")
+               .journals.create!(notes: "高速に検索できます。 オープンソースです。")
+        end
       fts_engine_pgroonga_open_source =
-        Issue.generate!(project: @project, subject: "ぴーじーるんが")
-             .journals.create!(
-                notes: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
-
+        perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+          Issue.generate!(project: @project, subject: "ぴーじーるんが")
+               .journals.create!(
+                 notes: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
+        end
       target_issue = fts_engine_groonga_open_source.issue
       similar_issues = target_issue.similar_issues(project_ids: [@project.id])
       assert_equal([fts_engine_pgroonga_open_source.issue],
                    similar_issues)
 
-      target_issue.journals.first.destroy
+      perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+        target_issue.journals.first.destroy
+      end
       similar_issues =
         target_issue.reload.similar_issues(project_ids: [@project.id])
       assert_equal([], similar_issues)
@@ -64,7 +77,9 @@ module FullTextSearch
               :original_filename => "Groonga 解説資料 最新版")}
         }
       )
-      fts_engine_groonga_latest_file.save!
+      perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+        fts_engine_groonga_latest_file.save!
+      end
       fts_engine_pgroonga_latest_file =
         Issue.generate!(project: @project, subject: "ぴーじーるんが")
       fts_engine_pgroonga_latest_file.save_attachments(
@@ -74,15 +89,18 @@ module FullTextSearch
               :original_filename => "PGroonga 解説資料 最新版")}
         }
       )
-      fts_engine_pgroonga_latest_file.save!
-
+      perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+        fts_engine_pgroonga_latest_file.save!
+      end
       similar_issues =
         fts_engine_groonga_latest_file
           .similar_issues(project_ids: [@project.id])
       assert_equal([fts_engine_pgroonga_latest_file],
                    similar_issues)
 
-      fts_engine_groonga_latest_file.attachments.first.destroy
+      perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
+        fts_engine_groonga_latest_file.attachments.first.destroy
+      end
       similar_issues =
         fts_engine_groonga_latest_file
           .reload

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -77,7 +77,8 @@ module FullTextSearch
       fts_engine_groonga.save_attachments(
         [
           {
-            "file" => mock_file_with_options(:original_filename => "test.txt"),
+            "file" => mock_file_with_options(
+              :original_filename => "groonga-latest.txt"),
             "description" => "高速に検索 オープンソース! 最新情報"
           }
         ]
@@ -90,7 +91,8 @@ module FullTextSearch
       fts_engine_pgroonga.save_attachments(
         [
           {
-            "file" => mock_file_with_options(:original_filename => "test.txt"),
+            "file" => mock_file_with_options(
+              :original_filename => "pgroonga-latest.txt"),
             "description" => "組み込んで高速に検索 オープンソース! 最新情報"
           }
         ]

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -1,0 +1,93 @@
+require File.expand_path("../../../test_helper", __FILE__)
+
+module FullTextSearch
+  class SimilarSearchIssueTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(1)
+      @project = Project.generate!
+      User.add_to_project(User.current, @project)
+    end
+
+    def test_same_structure_on_issue
+      fts_engine_groonga_open_source =
+        Issue.generate!(
+          project: @project,
+          subject: "ぐるんが",
+          description: "高速に検索できます。 オープンソースです。")
+      fts_engine_pgroonga_open_source =
+        Issue.generate!(
+          project: @project,
+          subject: "ぴーじーるんが",
+          description: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
+
+      similar_issues =
+        fts_engine_groonga_open_source.similar_issues(
+          project_ids: [@project.id])
+      assert_equal([fts_engine_pgroonga_open_source],
+                   similar_issues)
+
+      fts_engine_groonga_open_source.update!(description: nil)
+      similar_issues =
+        fts_engine_groonga_open_source.similar_issues(
+          project_ids: [@project.id])
+      assert_equal([], similar_issues)
+    end
+
+    def test_same_structure_with_journal
+      fts_engine_groonga_open_source =
+        Issue.generate!(project: @project, subject: "ぐるんが")
+             .journals.create!(notes: "高速に検索できます。 オープンソースです。")
+      fts_engine_pgroonga_open_source =
+        Issue.generate!(project: @project, subject: "ぴーじーるんが")
+             .journals.create!(
+                notes: "PostgreSQLに組み込んで高速に検索できます。 オープンソースです。")
+
+      target_issue = fts_engine_groonga_open_source.issue
+      similar_issues = target_issue.similar_issues(project_ids: [@project.id])
+      assert_equal([fts_engine_pgroonga_open_source.issue],
+                   similar_issues)
+
+      target_issue.journals.first.destroy
+      similar_issues =
+        target_issue.reload.similar_issues(project_ids: [@project.id])
+      assert_equal([], similar_issues)
+    end
+
+    def test_same_structure_with_attachment
+      set_tmp_attachments_directory
+      fts_engine_groonga_latest_file =
+        Issue.generate!(project: @project, subject: "ぐるんが")
+      fts_engine_groonga_latest_file.save_attachments(
+        {
+          '1' => {
+            'file' => mock_file_with_options(
+              :original_filename => "Groonga 解説資料 最新版")}
+        }
+      )
+      fts_engine_groonga_latest_file.save!
+      fts_engine_pgroonga_latest_file =
+        Issue.generate!(project: @project, subject: "ぴーじーるんが")
+      fts_engine_pgroonga_latest_file.save_attachments(
+        {
+          '1' => {
+            'file' => mock_file_with_options(
+              :original_filename => "PGroonga 解説資料 最新版")}
+        }
+      )
+      fts_engine_pgroonga_latest_file.save!
+
+      similar_issues =
+        fts_engine_groonga_latest_file
+          .similar_issues(project_ids: [@project.id])
+      assert_equal([fts_engine_pgroonga_latest_file],
+                   similar_issues)
+
+      fts_engine_groonga_latest_file.attachments.first.destroy
+      similar_issues =
+        fts_engine_groonga_latest_file
+          .reload
+          .similar_issues(project_ids: [@project.id])
+      assert_equal([], similar_issues)
+    end
+  end
+end

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -4,6 +4,9 @@ module FullTextSearch
   class SimilarSearchIssueTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
+    fixtures :roles
+    fixtures :users
+
     def setup
       IssueContent.destroy_all
       User.current = User.find(1)

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -75,11 +75,12 @@ module FullTextSearch
       fts_engine_groonga_latest =
         Issue.generate!(project: @project, subject: "ぐるんが")
       fts_engine_groonga_latest.save_attachments(
-        {
-          '1' => {
-            'file' => mock_file_with_options(
-              :original_filename => "高速に検索 オープンソース! 最新情報")}
-        }
+        [
+          {
+            "file" => mock_file_with_options(:original_filename => "test.txt"),
+            "description" => "高速に検索 オープンソース! 最新情報"
+          }
+        ]
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
         fts_engine_groonga_latest.save!
@@ -87,11 +88,12 @@ module FullTextSearch
       fts_engine_pgroonga_latest =
         Issue.generate!(project: @project, subject: "ぴーじーるんが")
       fts_engine_pgroonga_latest.save_attachments(
-        {
-          '1' => {
-            'file' => mock_file_with_options(
-              :original_filename => "組み込んで高速に検索 オープンソース! 最新情報")}
-        }
+        [
+          {
+            "file" => mock_file_with_options(:original_filename => "test.txt"),
+            "description" => "組み込んで高速に検索 オープンソース! 最新情報"
+          }
+        ]
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
         fts_engine_pgroonga_latest.save!

--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -72,9 +72,9 @@ module FullTextSearch
 
     def test_same_structure_with_attachment
       set_tmp_attachments_directory
-      fts_engine_groonga_latest =
+      fts_engine_groonga =
         Issue.generate!(project: @project, subject: "ぐるんが")
-      fts_engine_groonga_latest.save_attachments(
+      fts_engine_groonga.save_attachments(
         [
           {
             "file" => mock_file_with_options(:original_filename => "test.txt"),
@@ -83,11 +83,11 @@ module FullTextSearch
         ]
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_groonga_latest.save!
+        fts_engine_groonga.save!
       end
-      fts_engine_pgroonga_latest =
+      fts_engine_pgroonga =
         Issue.generate!(project: @project, subject: "ぴーじーるんが")
-      fts_engine_pgroonga_latest.save_attachments(
+      fts_engine_pgroonga.save_attachments(
         [
           {
             "file" => mock_file_with_options(:original_filename => "test.txt"),
@@ -96,19 +96,19 @@ module FullTextSearch
         ]
       )
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_pgroonga_latest.save!
+        fts_engine_pgroonga.save!
       end
       similar_issues =
-        fts_engine_groonga_latest
+        fts_engine_groonga
           .similar_issues(project_ids: [@project.id])
-      assert_equal([fts_engine_pgroonga_latest],
+      assert_equal([fts_engine_pgroonga],
                    similar_issues)
 
       perform_enqueued_jobs(only: FullTextSearch::UpdateIssueContentJob) do
-        fts_engine_groonga_latest.attachments.first.destroy
+        fts_engine_groonga.attachments.first.destroy
       end
       similar_issues =
-        fts_engine_groonga_latest
+        fts_engine_groonga
           .reload
           .similar_issues(project_ids: [@project.id])
       assert_equal([], similar_issues)


### PR DESCRIPTION
GitHub: GH-163

This change enhances the update process for issue
content by including attachment information,
the attachment's filename and description in the
content used for full-text searches.

It ensures that when an attachment associated with an issue is updated or removed, the issue's searchable content is also updated accordingly.

This change is part of the ongoing work to support AND-based searches across multiple fields by extending the search targets to include attachments.