### PR TITLE
similar_searcher: fix test failures by adding missing fixtures

### DIFF
--- a/test/unit/full_text_search/similar_search_issue_test.rb
+++ b/test/unit/full_text_search/similar_search_issue_test.rb
@@ -4,7 +4,10 @@ module FullTextSearch
   class SimilarSearchIssueTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
+    fixtures :enumerations
+    fixtures :issue_statuses
     fixtures :roles
+    fixtures :trackers
     fixtures :users
 
     def setup


### PR DESCRIPTION
## Problem

The tests are failed as follows.

```
E

Error:
FullTextSearch::SimilarSearchIssueTest#test_same_structure_on_issue:
ActiveRecord::RecordInvalid: Validation failed: Tracker cannot be blank, Priority cannot be blank, Status cannot be blank
    test/object_helpers.rb:107:in `generate!'
    plugins/full_text_search/test/unit/full_text_search/similar_search_issue_test.rb:20:in `block in test_same_structure_on_issue'
    plugins/full_text_search/test/unit/full_text_search/similar_search_issue_test.rb:19:in `test_same_structure_on_issue'

rails test plugins/full_text_search/test/unit/full_text_search/similar_search_issue_test.rb:17
```

ref: https://github.com/clear-code/redmine_full_text_search/actions/runs/14164033981/job/39674095903?pr=166#logs

## Cause

The test failures occurred because the necessary fixtures for enumerations, issue statuses, and trackers were not loaded.
As a result, when generating issues during tests, mandatory fields were missing, which led to validation errors.

## Solution

We add the missing fixture declarations in the test file.