### PR TITLE
test: wait for target elements to be rendered

### DIFF
--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -48,11 +48,19 @@ module FullTextSearch
                "See also: https://github.com/titusfortner/webdrivers/pull/251")
         end
       end
+      # The default max wait time is 2 seconds in Capybara. But in these tests.
+      # it's not enough to wait for the search results to be displayed in CI.
+      @default_max_wait_time = Capybara.default_max_wait_time
+      Capybara.default_max_wait_time = 5
 
       Target.destroy_all
       batch_runner = BatchRunner.new(show_progress: false)
       batch_runner.synchronize
       log_user("jsmith", "jsmith")
+    end
+
+    teardown do
+      Capybara.default_max_wait_time = @default_max_wait_time
     end
 
     def test_keep_search_target

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -51,7 +51,7 @@ module FullTextSearch
       # The default max wait time is 2 seconds in Capybara. But in these tests.
       # it's not enough to wait for the search results to be displayed in CI.
       @default_max_wait_time = Capybara.default_max_wait_time
-      Capybara.default_max_wait_time = 5
+      Capybara.default_max_wait_time = 10
 
       Target.destroy_all
       batch_runner = BatchRunner.new(show_progress: false)

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -68,6 +68,7 @@ module FullTextSearch
       click_on("search-target-wiki-pages")
       fill_in("search-input", with: "cookbook")
       click_on("search-submit")
+      wait_for_ajax
       within("#search-result #search-result-content #search-source-types") do
         wiki_tab = find(:link, "search-target-wiki-pages")
         assert_equal("selected", wiki_tab["class"])
@@ -80,6 +81,7 @@ module FullTextSearch
                     action: "index",
                     id: subproject1.identifier))
       click_on("search-target-issues")
+      wait_for_ajax
       within("#search-result #search-result-content #search-results") do
         assert_selector "li", count: 2
       end
@@ -91,6 +93,7 @@ module FullTextSearch
     def test_pagination
       visit(search_url)
       click_on("search-target-issues")
+      wait_for_ajax
       within("#search-result #search-result-content #search-results") do
         assert_selector "li", count: 10
       end

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -68,8 +68,10 @@ module FullTextSearch
       click_on("search-target-wiki-pages")
       fill_in("search-input", with: "cookbook")
       click_on("search-submit")
-      wiki_tab = find(:link, "search-target-wiki-pages")
-      assert_equal("selected", wiki_tab["class"])
+      within("#search-result #search-result-content #search-source-types") do
+        wiki_tab = find(:link, "search-target-wiki-pages")
+        assert_equal("selected", wiki_tab["class"])
+      end
     end
 
     def test_no_pagination
@@ -78,19 +80,27 @@ module FullTextSearch
                     action: "index",
                     id: subproject1.identifier))
       click_on("search-target-issues")
-      assert_selector "#search-results li", count: 2
-      assert_selector ".pagination li", count: 0
+      within("#search-result #search-result-content #search-results") do
+        assert_selector "li", count: 2
+      end
+      within("#search-result #search-result-content .pagination") do
+        assert_selector "li", count: 0
+      end
     end
 
     def test_pagination
       visit(search_url)
       click_on("search-target-issues")
-      assert_selector "#search-results li", count: 10
-      within(".pagination") do
+      within("#search-result #search-result-content #search-results") do
+        assert_selector "li", count: 10
+      end
+      within("#search-result #search-result-content .pagination") do
         assert_equal("1", find(".current").text)
         find(".next a").click
       end
-      assert_selector "#search-results li", count: 10
+      within("#search-result #search-result-content #search-results") do
+        assert_selector "li", count: 10
+      end
     end
   end
 end

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -65,9 +65,9 @@ module FullTextSearch
 
     def test_keep_search_target
       visit(search_url)
-      click_on("search-target-wiki-pages")
+      find("#search-target-wiki-pages").click
       fill_in("search-input", with: "cookbook")
-      click_on("search-submit")
+      find("#search-submit").click
       wait_for_ajax
       within("#search-result #search-result-content #search-source-types") do
         wiki_tab = find(:link, "search-target-wiki-pages")
@@ -80,7 +80,7 @@ module FullTextSearch
       visit(url_for(controller: "search",
                     action: "index",
                     id: subproject1.identifier))
-      click_on("search-target-issues")
+      find("#search-target-issues").click
       wait_for_ajax
       within("#search-result #search-result-content #search-results") do
         assert_selector "li", count: 2
@@ -92,7 +92,7 @@ module FullTextSearch
 
     def test_pagination
       visit(search_url)
-      click_on("search-target-issues")
+      find("#search-target-issues").click
       wait_for_ajax
       within("#search-result #search-result-content #search-results") do
         assert_selector "li", count: 10

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -60,8 +60,8 @@ module FullTextSearch
       click_on("search-target-wiki-pages")
       fill_in("search-input", with: "cookbook")
       click_on("search-submit")
-      assert_equal("selected",
-                   find(:link, "search-target-wiki-pages")["class"])
+      wiki_tab = find(:link, "search-target-wiki-pages")
+      assert_equal("selected", wiki_tab["class"])
     end
 
     def test_no_pagination
@@ -70,27 +70,19 @@ module FullTextSearch
                     action: "index",
                     id: subproject1.identifier))
       click_on("search-target-issues")
-      within("#search-results") do
-        assert_equal(2, all("li").size)
-      end
-      within(".pagination") do
-        assert_equal([], all("li").to_a)
-      end
+      assert_selector "#search-results li", count: 2
+      assert_selector ".pagination li", count: 0
     end
 
     def test_pagination
       visit(search_url)
       click_on("search-target-issues")
-      within("#search-results") do
-        assert_equal(10, all("li").size)
-      end
+      assert_selector "#search-results li", count: 10
       within(".pagination") do
         assert_equal("1", find(".current").text)
         find(".next a").click
       end
-      within("#search-results") do
-        assert_equal(10, all("li").size)
-      end
+      assert_selector "#search-results li", count: 10
     end
   end
 end


### PR DESCRIPTION
## Problem

In CI, the following error somtimes happended.
It's because the assertion run before that target
elements are rendered.

```
Failure:
FullTextSearch::SearchTest#test_pagination [plugins/full_text_search/test/system/full_text_search/search_test.rb:85]:
--- expected
+++ actual
@@ -1 +1 @@
-10
+0

bin/rails test plugins/full_text_search/test/system/full_text_search/search_test.rb:81
```

## Solution

Using `#assert_selector` enables the test to wait for target elements to be rendered.

ref: https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FMatchers:assert_selector