### PR TITLE
Change the timing of checking ApplicationRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,0 @@
-# For backward compatibility with Redmine < 6.
-# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine >= 6.
-# ref: https://www.redmine.org/issues/38975
-unless defined?(ApplicationRecord)
-  ApplicationRecord = ActiveRecord::Base
-end

--- a/init.rb
+++ b/init.rb
@@ -29,6 +29,13 @@ Redmine::Plugin.register :full_text_search do
   settings partial: "settings/full_text_search"
 end
 
+# For backward compatibility with Redmine < 6.
+# ApplicationRecord is inherited from ActiveRecord Models instead of ActiveRecord::Base in Redmine >= 6.
+# ref: https://www.redmine.org/issues/38975
+unless defined?(ApplicationRecord)
+  ApplicationRecord = ActiveRecord::Base
+end
+
 Redmine::Search.map do |search|
   search.register :changes
 end


### PR DESCRIPTION
GitHub fixes GH-173

`ApplicationRecord` should be defined in Redmine 6.0, but `ApplicationRecord` is undefined when loading `app/models/application_record.rb`.
Move it to `init.rb` so that it can be properly checked in `defined?(ApplicationRecord)`.