### PR TITLE
Fix garbled text in Wiki

### DIFF
--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -18,7 +18,8 @@ module FullTextSearch
       return ["", []] unless html.present?
 
       document = Document.new
-      # We need .to_s for old Nokogiri. We can remove the .to_s after 1.17.0.
+      # We need .to_s for old Nokogiri. We can remove the .to_s after we drop support for Redmine < 6.0.
+      # Redmine 6.0 requires Nokogiri 1.18.3 or later.
       parser = Nokogiri::HTML::SAX::Parser.new(document, html.encoding.to_s)
       parser.parse(html)
       [document.text.strip, document.tag_ids]

--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -18,7 +18,7 @@ module FullTextSearch
       return ["", []] unless html.present?
 
       document = Document.new
-      parser = Nokogiri::HTML::SAX::Parser.new(document)
+      parser = Nokogiri::HTML::SAX::Parser.new(document, html.encoding)
       parser.parse(html)
       [document.text.strip, document.tag_ids]
     end

--- a/lib/full_text_search/markup_parser.rb
+++ b/lib/full_text_search/markup_parser.rb
@@ -18,7 +18,8 @@ module FullTextSearch
       return ["", []] unless html.present?
 
       document = Document.new
-      parser = Nokogiri::HTML::SAX::Parser.new(document, html.encoding)
+      # We need .to_s for old Nokogiri. We can remove the .to_s after 1.17.0.
+      parser = Nokogiri::HTML::SAX::Parser.new(document, html.encoding.to_s)
       parser.parse(html)
       [document.text.strip, document.tag_ids]
     end


### PR DESCRIPTION
GitHub fixes GH-176

The default value for encoding in `Nokogiri::HTML::SAX::Parser.new` has changed since Nokogiri 1.17.0.

* 1.16.8: https://github.com/sparklemotion/nokogiri/blob/v1.16.8/lib/nokogiri/xml/sax/parser.rb#L72
  * `def initialize(doc = Nokogiri::XML::SAX::Document.new, encoding = "UTF-8")`
* 1.17.0: https://github.com/sparklemotion/nokogiri/blob/v1.17.0/lib/nokogiri/xml/sax/parser.rb#L95
  * `def initialize(doc = Nokogiri::XML::SAX::Document.new, encoding = nil)`
  * https://github.com/sparklemotion/nokogiri/commit/35596e7d747c9823fcecf55a05c210f72aa97bf2#diff-116e772eb2e47bb59e0798183732d07ef3312e480c764a6dc34b09f743a73f8c

This causes the encoding to be unspecified, resulting in garbled text.
Therefore, we changed it to specify `html.encoding`.