### PR TITLE
Update the status of Journal to the latest

### DIFF
--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -63,7 +63,7 @@ module FullTextSearch
                        Tag.issue_status(issue.status_id),
                      ].sort_by(&:id),
                    ],
-                   journal_targets.order(:id).collect(&:tags))
+                   journal_targets.collect {|target| target.tags.sort_by(&:id)})
     end
 
     def test_destroy

--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -61,9 +61,9 @@ module FullTextSearch
                        Tag.user(journal.user_id),
                        Tag.tracker(issue.tracker_id),
                        Tag.issue_status(issue.status_id),
-                     ],
+                     ].sort_by {|t| t.id },
                    ],
-                   journal_targets.collect(&:tags))
+                   journal_targets.order(:id).collect(&:tags))
     end
 
     def test_destroy

--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -49,30 +49,21 @@ module FullTextSearch
         status: IssueStatus.find_by_name("New"),
         tracker: Tracker.find_by_name("Bug")
       )
-      issue.reload
       journal = issue.journals.create!(notes: "comment")
-      journal.reload
       issue.status = IssueStatus.find_by_name("Closed")
       issue.tracker = Tracker.find_by_name("Support request")
       issue.save!
-      issue.reload
 
-      # Redmine 5.0 doesn't have updated_on
-      if journal.respond_to?(:updated_on)
-        last_modified_at = journal.updated_on
-      else
-        last_modified_at = journal.created_on
-      end
       journal_targets = Target.where(source_id: journal.id,
                                      source_type_id: Type.journal.id)
       assert_equal([
                      [
-                       Tag.user(journal.user_id).id,
-                       Tag.tracker(issue.tracker_id).id,
-                       Tag.issue_status(issue.status_id).id,
+                       Tag.user(journal.user_id),
+                       Tag.tracker(issue.tracker_id),
+                       Tag.issue_status(issue.status_id),
                      ],
                    ],
-                   journal_targets.collect {|target| target.tag_ids})
+                   journal_targets.collect(&:tags))
     end
 
     def test_destroy

--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -44,6 +44,37 @@ module FullTextSearch
                    targets.collect {|target| target.attributes.except("id")})
     end
 
+    def test_save_journal_status_and_tracker
+      issue = Issue.generate!(
+        status: IssueStatus.find_by_name("New"),
+        tracker: Tracker.find_by_name("Bug")
+      )
+      issue.reload
+      journal = issue.journals.create!(notes: "comment")
+      journal.reload
+      issue.status = IssueStatus.find_by_name("Closed")
+      issue.tracker = Tracker.find_by_name("Support request")
+      issue.save!
+      issue.reload
+
+      # Redmine 5.0 doesn't have updated_on
+      if journal.respond_to?(:updated_on)
+        last_modified_at = journal.updated_on
+      else
+        last_modified_at = journal.created_on
+      end
+      journal_targets = Target.where(source_id: journal.id,
+                                     source_type_id: Type.journal.id)
+      assert_equal([
+                     [
+                       Tag.user(journal.user_id).id,
+                       Tag.tracker(issue.tracker_id).id,
+                       Tag.issue_status(issue.status_id).id,
+                     ],
+                   ],
+                   journal_targets.collect {|target| target.tag_ids})
+    end
+
     def test_destroy
       searchable_custom_field = custom_fields(:custom_fields_002)
       issue = Issue.generate! do |i|

--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -61,7 +61,7 @@ module FullTextSearch
                        Tag.user(journal.user_id),
                        Tag.tracker(issue.tracker_id),
                        Tag.issue_status(issue.status_id),
-                     ].sort_by {|t| t.id },
+                     ].sort_by(&:id),
                    ],
                    journal_targets.order(:id).collect(&:tags))
     end


### PR DESCRIPTION
GitHub fixes GH-171

Problem:
When `tag_ids` of an issue is updated, `tag_ids` of journal is not updated. The `tag_ids` stores status and tracker information.

Solution:
When `tag_ids` of an issue is updated, the information of journal is also updated.

We have an issue that has been resolved with https://github.com/clear-code/redmine_full_text_search/commit/2507b826f4a64ba68bb3b0de0d250c46f4163646, so when we update all journals, we do not create new FTS target.