### PR TITLE
ci: fix flaky test by ensuring element state before assertion

### DIFF
--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -60,8 +60,14 @@ module FullTextSearch
       click_on("search-target-wiki-pages")
       fill_in("search-input", with: "cookbook")
       click_on("search-submit")
-      assert_equal("selected",
-                   find(:link, "search-target-wiki-pages")["class"])
+      within("#search-result") do
+        within("#search-result-content") do
+          within("#search-source-types") do
+            assert find_link("search-target-wiki-pages",
+                             class: "selected")
+          end
+        end
+      end
     end
 
     def test_no_pagination


### PR DESCRIPTION
The test was intermittently failing on CI due to a race condition:
- The previous implementation found the link element before its class attribute was updated to "selected"
- The assertion would then check the class while it was still being modified, causing failures
- Locally, the DOM updates were fast enough that the class was already changed when find() captured the element

This PR fixes the issue by using find_link() with the expected class parameter, which waits for the element to have the "selected" class before proceeding with the assertion. The within blocks ensure proper scoping of the element search.