### PR TITLE
fix: use db:migrate:reset for Rails 8.0+ in dev initialization

### DIFF
--- a/dev/initialize-redmine.sh
+++ b/dev/initialize-redmine.sh
@@ -18,7 +18,12 @@ fi
 ${RUBY:-ruby} bin/rails db:drop || true
 ${RUBY:-ruby} bin/rails generate_secret_token
 ${RUBY:-ruby} bin/rails db:create
-${RUBY:-ruby} bin/rails db:migrate
+rails_version_major=$(grep "^gem 'rails'" Gemfile | grep -o '[0-9]*' | head -n1)
+if [ ${rails_version_major} -ge 8 ]; then
+  ${RUBY:-ruby} bin/rails db:migrate:reset
+else
+  ${RUBY:-ruby} bin/rails db:migrate
+fi
 ${RUBY:-ruby} bin/rails redmine:load_default_data REDMINE_LANG=en
 ${RUBY:-ruby} bin/rails redmine:plugins:migrate
 


### PR DESCRIPTION
Rails 8.0 changed `db:migrate` behavior to load schema before running migrations on fresh databases.

This causes "Couldn't find User with 'id'=1" errors when initializing Redmine with existing schema files. It's because this admin user is created in migration file.

```
/home/otegami/.rbenv/versions/3.4.6/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2.1/lib/active_record/core.rb:280:in
'ActiveRecord::Core::ClassMethods#find': Couldn't find User with 'id'=1 (ActiveRecord::RecordNotFound)
```

Use `db:migrate:reset` for Rails 8.0+ which drops, recreates the database and runs migrations from
scratch, matching the previous behavior.

Ref: https://guides.rubyonrails.org/8_0_release_notes.html#active-record-notable-changes