### PR TITLE
Add a rake task to create the semantic search index

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -26,7 +26,12 @@ Redmine::Plugin.register :full_text_search do
   # Redmine assumes that this is a path in Redmine's plugin directory. So we need to compute this from
   # __FILE__ not __dir__.
   directory File.dirname(File.absolute_path(__FILE__))
-  settings partial: "settings/full_text_search"
+  settings partial: "settings/full_text_search",
+           default: {
+             "semantic_model" => "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",
+             "semantic_passage_prefix" => "passage: ",
+             "semantic_query_prefix" => "query: ",
+           }
 end
 
 # For backward compatibility with Redmine < 6.

--- a/lib/full_text_search/semantic_index.rb
+++ b/lib/full_text_search/semantic_index.rb
@@ -1,0 +1,94 @@
+require_relative "migration"
+
+module FullTextSearch
+  class SemanticIndex
+    INDEX_NAME = "fts_targets_semantic_index_pgroonga"
+
+    INDEX_COLUMNS = [
+      "id",
+      "source_id",
+      "source_type_id",
+      "project_id",
+      "container_id",
+      "container_type_id",
+      "custom_field_id",
+      "is_private",
+      "last_modified_at",
+      "registered_at",
+      "title",
+      "tag_ids"
+    ]
+
+    class << self
+      def available?
+        Redmine::Database.postgresql?
+      end
+
+      def exist?
+        return false unless available?
+        connection.select_value(
+          "SELECT to_regclass(#{connection.quote(INDEX_NAME)})::text"
+        ).present?
+      end
+
+      def table_name
+        Target.table_name
+      end
+
+      def ensure_created(concurrently: false)
+        return false unless available?
+        return :exist if exist?
+        connection.add_index(
+          table_name,
+          ["content", *INDEX_COLUMNS],
+          name: INDEX_NAME,
+          using: :pgroonga,
+          opclass: {content: :pgroonga_text_semantic_search_ops_v2},
+          with: build_with,
+          algorithm: (concurrently ? :concurrently : nil),
+          if_not_exists: true
+        )
+        :created
+      end
+
+      def ensure_dropped(concurrently: false)
+        return false unless available?
+        connection.remove_index(
+          table_name,
+          name: INDEX_NAME,
+          if_exists: true,
+          algorithm: (concurrently ? :concurrently : nil)
+        )
+        true
+      end
+
+      def model
+        settings.semantic_model
+      end
+
+      private
+
+      def settings
+        Setting.plugin_full_text_search
+      end
+
+      def build_with
+        options = [
+          "plugins = #{connection.quote('language_model/knn')}",
+          "model = #{connection.quote(settings.semantic_model)}",
+        ]
+        if settings.semantic_passage_prefix
+          options << "passage_prefix = #{connection.quote(settings.semantic_passage_prefix)}"
+        end
+        if settings.semantic_query_prefix
+          options << "query_prefix = #{connection.quote(settings.semantic_query_prefix)}"
+        end
+        options.join(",")
+      end
+
+      def connection
+        ActiveRecord::Base.connection
+      end
+    end
+  end
+end

--- a/lib/full_text_search/settings.rb
+++ b/lib/full_text_search/settings.rb
@@ -25,6 +25,22 @@ module FullTextSearch
       @raw["enable_tracking"] != FALSE_VALUE
     end
 
+    def enable_semantic_search?
+      @raw["enable_semantic_search"] == TRUE_VALUE
+    end
+
+    def semantic_model
+      @raw["semantic_model"].presence
+    end
+
+    def semantic_passage_prefix
+      @raw["semantic_passage_prefix"].presence
+    end
+
+    def semantic_query_prefix
+      @raw["semantic_query_prefix"].presence
+    end
+
     DEFAULT_ATTACHMENT_MAX_TEXT_SIZE_IN_MB = 4
     def attachment_max_text_size_in_mb
       size = @raw.fetch("attachment_max_text_size_in_mb",

--- a/lib/tasks/full_text_search.rake
+++ b/lib/tasks/full_text_search.rake
@@ -97,4 +97,25 @@ namespace :full_text_search do
       synchronizer.synchronize
     end
   end
+
+  namespace :semantic do
+    namespace :index do
+      desc "Create semantic search index (PostgreSQL + PGroonga only)"
+      task :create => :environment do
+        case FullTextSearch::SemanticIndex.ensure_created(concurrently: ENV["CONCURRENTLY"] == "1")
+        when :created
+          puts "Created: #{FullTextSearch::SemanticIndex::INDEX_NAME} (model: #{FullTextSearch::SemanticIndex.model})"
+        when :exist
+          puts "Already exists: #{FullTextSearch::SemanticIndex::INDEX_NAME}"
+        else
+          puts "Skipped: semantic search index is PostgreSQL + PGroonga only"
+        end
+      end
+
+      desc "Drop semantic search index"
+      task :drop => :environment do
+        FullTextSearch::SemanticIndex.ensure_dropped(concurrently: ENV["CONCURRENTLY"] == "1")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Semantic search needs a GPU, so its index is not created via a migration.
Only users who want it set it up.

The search feature will be implemented later.