### PR TITLE
Add request parameters for semantic search

### DIFF
--- a/app/models/full_text_search/request.rb
+++ b/app/models/full_text_search/request.rb
@@ -21,6 +21,7 @@ module FullTextSearch
     attr_writer :order_type
     attr_writer :options
     attr_accessor :tags
+    attr_writer :semantic
 
     Redmine::Search.available_search_types.each do |type|
       attr_accessor type
@@ -48,6 +49,7 @@ module FullTextSearch
         "order_target" => custom_params[:order_target] || order_target,
         "order_type" => custom_params[:order_type] || order_type,
         "options" => options,
+        "semantic" => semantic,
       }
       to_params_types(params, custom_params)
       to_params_order_type(params, custom_params)
@@ -131,6 +133,14 @@ module FullTextSearch
 
     def options
       @options.presence || "0"
+    end
+
+    def semantic
+      @semantic.presence || "0"
+    end
+
+    def semantic?
+      semantic == "1"
     end
 
     def search_types

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -79,6 +79,10 @@
             </label>
           </p>
         </fieldset>
+        <% if fts_enable_semantic_search? %>
+          <p><label><%= form.check_box "semantic", name: "semantic" %>
+                    <%= l(:label_full_text_search_search_semantic) %></label></p>
+        <% end %>
       </div>
     </fieldset>
     <%= form.hidden_field "options", id: "show-options", name: "options" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
   label_full_text_search_semantic_passage_prefix: Passage prefix
   label_full_text_search_semantic_query_prefix: Query prefix
   text_full_text_search_semantic_note: Semantic search requires PostgreSQL + PGroonga and a dedicated index created via rake full_text_search:semantic:index:create.
+  label_full_text_search_search_semantic: Search semantically
   label_similar_issues: Similar issues
   label_extension: Extension
   label_text_extraction: Text extraction

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
   label_full_text_search_semantic_passage_prefix: パッセージのプレフィックス
   label_full_text_search_semantic_query_prefix: クエリーのプレフィックス
   text_full_text_search_semantic_note: セマンティックサーチにはPostgreSQL + PGroongaと、rake full_text_search:semantic:index:createで作成する専用インデックスが必要です。
+  label_full_text_search_search_semantic: セマンティックに検索
   label_similar_issues: 類似チケット
   label_extension: 拡張子
   label_text_extraction: テキスト抽出

--- a/lib/full_text_search/hooks/controller_search_index.rb
+++ b/lib/full_text_search/hooks/controller_search_index.rb
@@ -6,6 +6,10 @@ module FullTextSearch
         @search_request.user = User.current
         @search_request.project = @project
 
+        unless Setting.plugin_full_text_search.enable_semantic_search?
+          @search_request.semantic = "0"
+        end
+
         page = (params[:page].presence || 1).to_i
         case params[:format]
         when 'xml', 'json'
@@ -60,6 +64,7 @@ module FullTextSearch
           :order_target,
           :order_type,
           :options,
+          :semantic,
         ]
         Redmine::Search.available_search_types.each do |type|
           permitted_names << type.to_sym

--- a/lib/full_text_search/hooks/settings_helper.rb
+++ b/lib/full_text_search/hooks/settings_helper.rb
@@ -12,6 +12,10 @@ module FullTextSearch
       def fts_enable_tracking?
         Setting.plugin_full_text_search.enable_tracking?
       end
+
+      def fts_enable_semantic_search?
+        Setting.plugin_full_text_search.enable_semantic_search?
+      end
     end
   end
 end

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -249,6 +249,28 @@ module FullTextSearch
         end
       end
 
+      def test_semantic_checkbox_visible_when_enabled
+        with_settings(plugin_full_text_search: {"enable_semantic_search" => "1"}) do
+          get :index
+        end
+        assert_select("input[type=checkbox][name=?]", "semantic")
+      end
+
+      def test_semantic_checkbox_hidden_when_disabled
+        with_settings(plugin_full_text_search: {"enable_semantic_search" => "0"}) do
+          get :index
+        end
+        assert_select("input[type=checkbox][name=?]", "semantic", false)
+      end
+
+      def test_semantic_ignored_when_disabled
+        project = Project.first
+        with_settings(plugin_full_text_search: {"enable_semantic_search" => "0"}) do
+          get :index, params: {"id" => project.identifier, "semantic" => "1"}
+        end
+        assert_select("a[href*=?]", "semantic=1", false)
+      end
+
       def test_search_order_links
         project = Project.first
         get :index, params: {"id" => project.identifier}
@@ -285,6 +307,7 @@ module FullTextSearch
             "q" => "",
             "titles_only" => "0",
             "wiki_pages" => "1",
+            "semantic" => "0",
             "search_id" => @search_id,
           }
           expected_search_path = "/projects/#{project.identifier}/search"
@@ -358,6 +381,7 @@ module FullTextSearch
             "order_type" => "desc",
             "q" => "",
             "titles_only" => "0",
+            "semantic" => "0",
             "search_id" => @search_id,
           }
           expected_search_path = "/projects/#{project.identifier}/search"


### PR DESCRIPTION
If this parameter is enabled, semantic search will be performed.
The core logic for semantic search will be implemented later.