### PR TITLE
fix: use `@record.title` for attachment search result title

### DIFF
--- a/lib/full_text_search/attachment_mapper.rb
+++ b/lib/full_text_search/attachment_mapper.rb
@@ -138,7 +138,7 @@ JOIN projects
 
   class FtsAttachmentMapper < FtsMapper
     def title
-      @record.filename
+      @record.title
     end
 
     def url


### PR DESCRIPTION
`@record` is an FtsTarget (not an Attachment), so use FtsTarget#title.