### PR TITLE
Add SemanticSearcher for semantic search

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -83,6 +83,7 @@ FullTextSearch::Hooks::IssuesShowDescriptionBottomHook
 FullTextSearch::Hooks::SimilarIssuesHelper
 
 FullTextSearch::Searcher
+FullTextSearch::SemanticSearcher
 FullTextSearch::SimilarSearcher
 
 class << Setting

--- a/lib/full_text_search/hooks/controller_search_index.rb
+++ b/lib/full_text_search/hooks/controller_search_index.rb
@@ -29,7 +29,6 @@ module FullTextSearch
           return
         end
 
-        searcher = Searcher.new(@search_request)
         @result_set = searcher.search
         context = @search_request.to_params
         context = context.merge("user_id" => @search_request.user.id,
@@ -71,6 +70,14 @@ module FullTextSearch
         end
         params.permit(*permitted_names,
                       tags: [])
+      end
+
+      def searcher
+        if @search_request.semantic? && SemanticIndex.exist?
+          SemanticSearcher.new(@search_request)
+        else
+          Searcher.new(@search_request)
+        end
       end
     end
   end

--- a/lib/full_text_search/mroonga.rb
+++ b/lib/full_text_search/mroonga.rb
@@ -3,7 +3,7 @@ module FullTextSearch
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def select(command)
+      def select(command, index_name: nil)
         sql = build_sql(command)
         now = Time.zone.now.to_f
         raw_response = connection.select_value(sql)

--- a/lib/full_text_search/mroonga.rb
+++ b/lib/full_text_search/mroonga.rb
@@ -3,7 +3,7 @@ module FullTextSearch
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def select(command, index_name: nil)
+      def select(command, semantic: false)
         sql = build_sql(command)
         now = Time.zone.now.to_f
         raw_response = connection.select_value(sql)

--- a/lib/full_text_search/pgroonga.rb
+++ b/lib/full_text_search/pgroonga.rb
@@ -3,8 +3,8 @@ module FullTextSearch
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def select(command)
-        sql = build_sql(command)
+      def select(command, index_name: pgroonga_index_name)
+        sql = build_sql(command, index_name: index_name)
         raw_response = connection.select_value(sql)
         Groonga::Client::Response.parse(command, raw_response)
       end
@@ -45,10 +45,10 @@ SHOW pgroonga.libgroonga_version;
       end
 
       private
-      def build_sql(command)
+      def build_sql(command, index_name: pgroonga_index_name)
         arguments = []
         placeholders = []
-        command["table"] = "pgroonga_table_name('#{pgroonga_index_name}')"
+        command["table"] = "pgroonga_table_name('#{index_name}')"
         if command["filter"].present?
           command["filter"] += " && pgroonga_tuple_is_alive(ctid)"
         else

--- a/lib/full_text_search/pgroonga.rb
+++ b/lib/full_text_search/pgroonga.rb
@@ -3,8 +3,8 @@ module FullTextSearch
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def select(command, index_name: pgroonga_index_name)
-        sql = build_sql(command, index_name: index_name)
+      def select(command, semantic: false)
+        sql = build_sql(command, semantic: semantic)
         raw_response = connection.select_value(sql)
         Groonga::Client::Response.parse(command, raw_response)
       end
@@ -45,7 +45,8 @@ SHOW pgroonga.libgroonga_version;
       end
 
       private
-      def build_sql(command, index_name: pgroonga_index_name)
+      def build_sql(command, semantic: false)
+        index_name = semantic ? SemanticIndex::INDEX_NAME : pgroonga_index_name
         arguments = []
         placeholders = []
         command["table"] = "pgroonga_table_name('#{index_name}')"

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -29,7 +29,7 @@ module FullTextSearch
       if not_search_type_conditions.empty?
         prefix = ""
       else
-        if Target.use_slices?
+        if use_slices?
           prefix = "slices[type_filtered]."
           arguments["#{prefix}filter"] =
             (["all_records()"] + not_search_type_conditions).join(" &! ")
@@ -72,12 +72,20 @@ module FullTextSearch
       arguments["#{prefix}limit"] = limit
       arguments["filter"] = "false" unless arguments["filter"]
       command = Groonga::Command::Select.new("select", arguments)
-      response = Target.select(command)
+      response = Target.select(command, index_name: index_name)
       raise Groonga::Client::Error, response.message unless response.success?
       ResultSet.new(response)
     end
 
     private
+    def index_name
+      Target.pgroonga_index_name
+    end
+
+    def use_slices?
+      Target.use_slices?
+    end
+
     def match_columns
       if @request.titles_only?
         ["title"]

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -72,14 +72,14 @@ module FullTextSearch
       arguments["#{prefix}limit"] = limit
       arguments["filter"] = "false" unless arguments["filter"]
       command = Groonga::Command::Select.new("select", arguments)
-      response = Target.select(command, index_name: index_name)
+      response = Target.select(command, semantic: semantic?)
       raise Groonga::Client::Error, response.message unless response.success?
       ResultSet.new(response)
     end
 
     private
-    def index_name
-      Target.pgroonga_index_name
+    def semantic?
+      false
     end
 
     def use_slices?

--- a/lib/full_text_search/semantic_searcher.rb
+++ b/lib/full_text_search/semantic_searcher.rb
@@ -3,8 +3,8 @@ module FullTextSearch
     K = 50
 
     private
-    def index_name
-      SemanticIndex::INDEX_NAME
+    def semantic?
+      true
     end
 
     def use_slices?

--- a/lib/full_text_search/semantic_searcher.rb
+++ b/lib/full_text_search/semantic_searcher.rb
@@ -1,0 +1,40 @@
+module FullTextSearch
+  class SemanticSearcher < Searcher
+    K = 50
+
+    private
+    def index_name
+      SemanticIndex::INDEX_NAME
+    end
+
+    def use_slices?
+      false
+    end
+
+    def query
+      nil
+    end
+
+    def match_columns
+      []
+    end
+
+    def knn_expression
+      query = Groonga::Client::ScriptSyntax.format_string(@request.query)
+      %Q[language_model_knn(content, #{query}, {"k": #{K}})]
+    end
+
+    def filter
+      return "false" if @request.query.blank?
+
+      visibility = super
+      return "false" unless visibility
+
+      "#{knn_expression} && (#{visibility})"
+    end
+
+    def sort_keys
+      ["-#{knn_expression}"]
+    end
+  end
+end

--- a/test/unit/full_text_search/semantic_searcher_test.rb
+++ b/test/unit/full_text_search/semantic_searcher_test.rb
@@ -17,6 +17,7 @@ module FullTextSearch
     end
 
     def teardown
+      return unless ENV["SEMANTIC_SEARCH_TEST"]
       SemanticIndex.ensure_dropped
     end
 

--- a/test/unit/full_text_search/semantic_searcher_test.rb
+++ b/test/unit/full_text_search/semantic_searcher_test.rb
@@ -1,0 +1,44 @@
+require File.expand_path("../../../test_helper", __FILE__)
+
+module FullTextSearch
+  class SemanticSearcherTest < ActiveSupport::TestCase
+    include PrettyInspectable
+
+    fixtures :projects
+    fixtures :users
+
+    def setup
+      skip("Set SEMANTIC_SEARCH_TEST=1 to run semantic search tests") unless ENV["SEMANTIC_SEARCH_TEST"]
+      skip("Semantic search requires PostgreSQL + PGroonga") unless Redmine::Database.postgresql?
+
+      Target.destroy_all
+      @user = User.find(1)
+      @project = Project.find(1)
+    end
+
+    def teardown
+      SemanticIndex.ensure_dropped
+    end
+
+    def search(parameters={})
+      request = Request.new({semantic: "1"}.merge(parameters))
+      request.user = @user
+      request.project = @project
+      SemanticSearcher.new(request).search
+    end
+
+    def test_semantic_search
+      cat = Issue.generate!(project: @project,
+                            subject: "Pets",
+                            description: "The cat sleeps on the warm mat all day.")
+      market = Issue.generate!(project: @project,
+                               subject: "Economy",
+                               description: "Stock market prices rose sharply this quarter.")
+      with_settings(plugin_full_text_search: {"semantic_model" => "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF"}) do
+        SemanticIndex.ensure_created
+      end
+      assert_equal([cat, market],
+                   search({q: "a kitten resting on a rug", limit: 2}).records.collect(&:source_record))
+    end
+  end
+end


### PR DESCRIPTION
It basically just adds language_model_knn() to the Searcher's filter.
Overrode the keyword search only parts (e.g. `match_columns`) to do nothing.