### PR TITLE
Fix the tag search for Wiki Extension

### DIFF
--- a/lib/full_text_search/plugin_wiki_extensions_tag_searchable.rb
+++ b/lib/full_text_search/plugin_wiki_extensions_tag_searchable.rb
@@ -7,7 +7,7 @@ module FullTextSearch
 
     included do
       after_create :fts_after_create
-      after_destroy :fts_after_destroy
+      before_destroy :fts_before_destroy
     end
 
     private
@@ -29,7 +29,7 @@ module FullTextSearch
       fts_target.save!
     end
 
-    def fts_after_destroy
+    def fts_before_destroy
       fts_target = find_fts_target
       return unless fts_target
       fts_target.tag_ids -= [find_fts_tag_label_id]


### PR DESCRIPTION
Before, Wiki Extension's `destroy` function executed after `fts_after_destroy`.

But due to the following change to Wiki Extension, Wiki Extension's `after_destroy` method now executed first.
https://github.com/haru/redmine_wiki_extensions/commit/664fa199de9b695c4e16c3f4e3db9255991a7c8b

To ensure it runs before deletion, we'll execute it using `before_destroy` instead of `after_destroy`.