### PR TITLE
Update attachments when a wiki page moves to another project

### DIFF
--- a/lib/full_text_search/wiki_page_mapper.rb
+++ b/lib/full_text_search/wiki_page_mapper.rb
@@ -39,6 +39,12 @@ module FullTextSearch
       fts_target.last_modified_at = @record.updated_on
       fts_target.registered_at = @record.created_on
       fts_target.save!
+
+      # When a wiki page moves to another project, its attachments move with it,
+      # so we need to update them too.
+      if fts_target.saved_change_to_project_id? && !fts_target.saved_change_to_id?
+        update_attachments_project_id
+      end
     end
 
     private
@@ -47,6 +53,14 @@ module FullTextSearch
       @record.wiki_ext_tags.collect do |tag|
         Tag.label(tag.name).id
       end
+    end
+
+    def update_attachments_project_id
+      attachment_ids = @record.attachments.ids
+      return if attachment_ids.empty?
+      Target
+        .where(source_type_id: Type.attachment.id, source_id: attachment_ids)
+        .update_all(project_id: @record.wiki.project_id)
     end
   end
 

--- a/test/unit/full_text_search/wiki_page_test.rb
+++ b/test/unit/full_text_search/wiki_page_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path("../../../test_helper", __FILE__)
+
+module FullTextSearch
+  class WikiPageMapperTest < ActiveSupport::TestCase
+    fixtures :projects
+    fixtures :wikis
+    fixtures :users
+
+    def setup
+      @wiki = Project.find(1).wiki
+      @page = WikiPage.new(wiki: @wiki, title: "WikiPage")
+      content = WikiContent.new(page: @page)
+      @page.save_with_content(content)
+      @attachment = Attachment.generate!(container: @page, author: User.find(2))
+    end
+
+    def wiki_page_target
+      Target.find_by(source_id: @page.id,
+                     source_type_id: Type.wiki_page.id)
+    end
+
+    def attachment_target
+      Target.find_by(source_id: @attachment.id,
+                     source_type_id: Type.attachment.id)
+    end
+
+    def test_update_wiki_page
+      @page.title = "WikiPageNew"
+      @page.save!
+
+      assert_equal("WikiPageNew", wiki_page_target.title)
+    end
+
+    def test_move_project_update_attachments
+      to_wiki = Project.find(2).wiki
+      @page.wiki_id = to_wiki.id
+      @page.save!
+
+      assert_equal(2, wiki_page_target.project_id)
+      assert_equal(2, attachment_target.project_id)
+    end
+  end
+end


### PR DESCRIPTION
When a wiki page was moved to another project, the wiki page's `project_id` was updated correctly. But the `project_id` of the attachment attached to that wiki page was not updated and still linked to the old project.

When the project_id is updated on the wiki page, update the linked attachments as well.