### PR TITLE
change_mapper: skip `copy` in Subversion

### DIFF
--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -40,6 +40,17 @@ module FullTextSearch
         entry = RepositoryEntry.new(repository,
                                     @record.path,
                                     changeset.identifier)
+        if entry.directory?
+          return unless @record.from_path
+
+          # NOTE: We currently don't support copy, for the following reasons:
+          # * It seems unlikely that someone would commit the exact same files with only a copy.
+          # * It's hard to support given the data structure.
+          return unless directory_move_source?
+
+          # TODO: rename the moved directory's files in place.
+          return
+        end
         return unless entry.file?
         return if find_newer_fts_targets.exists?
 
@@ -119,6 +130,16 @@ module FullTextSearch
     private
     def target_title
       "#{@record.path}@#{@record.changeset.identifier}"
+    end
+
+    def directory_move_source?
+      # In the case of `move`, there is a `D` that pairs with `A`.
+      # This method checks whether such a `D` exists.
+      Change
+        .where(changeset_id: @record.changeset_id,
+               action: "D",
+               path: @record.from_path)
+        .exists?
     end
 
     def fts_target_keys

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -209,6 +209,23 @@ module FullTextSearch
       end
     end
 
+    def test_copy_directory
+      Dir.mktmpdir do |dir|
+        repository_url = build_copy_directory_repository(dir)
+        repository = Repository::Subversion.create(project: @project,
+                                                   url: repository_url)
+        repository.fetch_changesets
+
+        assert_not(
+          Target
+            .where(container_id: repository.id,
+                   container_type_id: Type.repository.id)
+            .where("title LIKE ?", "/copied/%")
+            .exists?
+        )
+      end
+    end
+
     private
     def run_command(*args)
       assert(system(*args), "Command failed: #{args.join(' ')}")
@@ -243,6 +260,14 @@ module FullTextSearch
       run_command("svn", "rm",
                   "#{repository_url}/dir",
                   "-m", "Delete dir")
+      repository_url
+    end
+
+    def build_copy_directory_repository(dir)
+      repository_url = create_test_repository(dir)
+      run_command("svn", "copy",
+                  "#{repository_url}/dir", "#{repository_url}/copied",
+                  "-m", "Copy dir to copied")
       repository_url
     end
   end


### PR DESCRIPTION
Related: GH-203

When we use `copy` in Subversion, the path becomes a directory.
We currently don't support copy, for the following reasons:

* It seems unlikely that someone would commit the exact same files with only a copy.
* It's hard to support given the data structure.