### PR TITLE
change_mapper: Support for `D` when the path is a directory in Subversion

### DIFF
--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -74,7 +74,16 @@ module FullTextSearch
           extract_content(fts_target, options)
         end
       when "D"
-        find_old_fts_targets.destroy_all
+        # For Subversion:
+        # When moving a directory, Changes are inserted in the form `D from_dir`, `A to_dir`.
+        # At that time, since we reuse the file level fts_target data from before the move,
+        # we do not delete it.
+        return if directory_move_destination?
+
+        # In the case of `D`, `entry.{file?,directory?}` is `nil` and cannot be used.
+        # Therefore, we use `find_old_fts_targets_with_descendants`, which can find targets
+        # in both file and directory.
+        find_old_fts_targets_with_descendants(@record.path).destroy_all
       end
     end
 
@@ -120,8 +129,20 @@ module FullTextSearch
       }
     end
 
-    def find_fts_targets
-      escaped_path = Target.sanitize_sql_like(@record.path)
+    def directory_move_destination?
+      change = Change
+        .where(changeset_id: @record.changeset_id,
+               action: ["A", "R"],
+               from_path: @record.path)
+        .first
+      return false unless change
+      entry = RepositoryEntry.new(change.changeset.repository,
+                                  change.path,
+                                  change.changeset.identifier)
+      entry.directory?
+    end
+
+    def find_fts_targets_by_repository
       Target
         .joins(<<-JOIN)
   JOIN changes
@@ -133,6 +154,11 @@ module FullTextSearch
     ON changesets.repository_id = repositories.id
         JOIN
         .where(repositories: {id: @record.changeset.repository.id})
+    end
+
+    def find_fts_targets
+      escaped_path = Target.sanitize_sql_like(@record.path)
+      find_fts_targets_by_repository
         # Exclude `@%@%` so that `file.txt@<revision>` doesn't match `file.txt@2026`
         # when both `file.txt` and `file.txt@2026` exist.
         .where("title LIKE ? AND title NOT LIKE ?",
@@ -142,6 +168,18 @@ module FullTextSearch
 
     def find_old_fts_targets
       find_fts_targets
+        .where(changesets: {id: -Float::INFINITY...@record.changeset_id})
+    end
+
+    def find_old_fts_targets_with_descendants(path)
+      escaped_path = Target.sanitize_sql_like(path)
+      find_fts_targets_by_repository
+        # Use `#{escaped_path}/%` as a condition to also support cases where `path` is a directory.
+        # See also the comments for `find_fts_targets`.
+        .where("(title LIKE ? AND title NOT LIKE ?) OR title LIKE ?",
+               "#{escaped_path}@%",
+               "#{escaped_path}@%@%",
+               "#{escaped_path}/%")
         .where(changesets: {id: -Float::INFINITY...@record.changeset_id})
     end
 

--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -81,9 +81,9 @@ module FullTextSearch
         return if directory_move_destination?
 
         # In the case of `D`, `entry.{file?,directory?}` is `nil` and cannot be used.
-        # Therefore, we use `find_old_fts_targets_with_descendants`, which can find targets
-        # in both file and directory.
-        find_old_fts_targets_with_descendants(@record.path).destroy_all
+        # Therefore, we use `descendants: true`, which can find targets in both file
+        # and directory.
+        find_old_fts_targets(descendants: true).destroy_all
       end
     end
 
@@ -142,7 +142,18 @@ module FullTextSearch
       entry.directory?
     end
 
-    def find_fts_targets_by_repository
+    def find_fts_targets(path: nil, descendants: false)
+      escaped_path = Target.sanitize_sql_like(path || @record.path)
+      # Exclude `@%@%` so that `file.txt@<revision>` doesn't match `file.txt@2026`
+      # when both `file.txt` and `file.txt@2026` exist.
+      condition = "title LIKE ? AND title NOT LIKE ?"
+      values = ["#{escaped_path}@%", "#{escaped_path}@%@%"]
+      if descendants
+        # Also match descendants, to support cases where `path` is a directory.
+        condition = "(#{condition}) OR title LIKE ?"
+        values << "#{escaped_path}/%"
+      end
+
       Target
         .joins(<<-JOIN)
   JOIN changes
@@ -154,32 +165,11 @@ module FullTextSearch
     ON changesets.repository_id = repositories.id
         JOIN
         .where(repositories: {id: @record.changeset.repository.id})
+        .where(condition, *values)
     end
 
-    def find_fts_targets
-      escaped_path = Target.sanitize_sql_like(@record.path)
-      find_fts_targets_by_repository
-        # Exclude `@%@%` so that `file.txt@<revision>` doesn't match `file.txt@2026`
-        # when both `file.txt` and `file.txt@2026` exist.
-        .where("title LIKE ? AND title NOT LIKE ?",
-               "#{escaped_path}@%",
-               "#{escaped_path}@%@%")
-    end
-
-    def find_old_fts_targets
-      find_fts_targets
-        .where(changesets: {id: -Float::INFINITY...@record.changeset_id})
-    end
-
-    def find_old_fts_targets_with_descendants(path)
-      escaped_path = Target.sanitize_sql_like(path)
-      find_fts_targets_by_repository
-        # Use `#{escaped_path}/%` as a condition to also support cases where `path` is a directory.
-        # See also the comments for `find_fts_targets`.
-        .where("(title LIKE ? AND title NOT LIKE ?) OR title LIKE ?",
-               "#{escaped_path}@%",
-               "#{escaped_path}@%@%",
-               "#{escaped_path}/%")
+    def find_old_fts_targets(path: nil, descendants: false)
+      find_fts_targets(path: path, descendants: descendants)
         .where(changesets: {id: -Float::INFINITY...@record.changeset_id})
     end
 

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -121,5 +121,129 @@ module FullTextSearch
                      records.first.attributes.except("id"),
                    ])
     end
+
+    def test_move_directory
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_repository(dir)
+        repository = Repository::Subversion.create(project: @project,
+                                                   url: repository_url)
+        repository.fetch_changesets
+
+        move_changeset = repository.changesets.find_by!(revision: "2")
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        original_b_change = Change.find_by!(path: "/dir/b.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        b_target = Target.find_by(source_id: original_b_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal([
+          {
+            "project_id" => @project.id,
+            "source_id" => original_a_change.id,
+            "source_type_id" => Type.change.id,
+
+            # TODO: Support for move
+            # "last_modified_at" => move_changeset.committed_on,
+            # "registered_at" => move_changeset.committed_on,
+            "last_modified_at" => original_a_change.changeset.committed_on,
+            "registered_at" => original_a_change.changeset.committed_on,
+
+            "container_id" => repository.id,
+            "container_type_id" => Type.repository.id,
+
+            # TODO: Support for move
+            # "title" => "/renamed/a.txt@2",
+            "title" => "/dir/a.txt@1",
+
+            "content" => "FILE: a.txt\n",
+            "custom_field_id" => null_number,
+            "is_private" => null_boolean,
+            "tag_ids" => [Tag.extension("txt").id],
+          },
+          {
+            "project_id" => @project.id,
+            "source_id" => original_b_change.id,
+            "source_type_id" => Type.change.id,
+
+            # TODO: Support for move
+            # "last_modified_at" => move_changeset.committed_on,
+            # "registered_at" => move_changeset.committed_on,
+            "last_modified_at" => original_b_change.changeset.committed_on,
+            "registered_at" => original_b_change.changeset.committed_on,
+
+            "container_id" => repository.id,
+            "container_type_id" => Type.repository.id,
+
+            # TODO: Support for move
+            # "title" => "/renamed/b.txt@2",
+            "title" => "/dir/b.txt@1",
+
+            "content" => "FILE: b.txt\n",
+            "custom_field_id" => null_number,
+            "is_private" => null_boolean,
+            "tag_ids" => [Tag.extension("txt").id],
+          },
+        ],
+        [
+          a_target.attributes.except("id"),
+          b_target.attributes.except("id"),
+        ])
+      end
+    end
+
+    def test_delete_directory
+      Dir.mktmpdir do |dir|
+        repository_url = build_delete_directory_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        original_b_change = Change.find_by!(path: "/dir/b.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        b_target = Target.find_by(source_id: original_b_change.id,
+                                  source_type_id: Type.change.id)
+
+        assert_equal([nil, nil], [a_target, b_target])
+      end
+    end
+
+    private
+    def run_command(*args)
+      assert(system(*args), "Command failed: #{args.join(' ')}")
+    end
+
+    def create_test_repository(dir)
+      repository_path = File.join(dir, "repository")
+      run_command("svnadmin", "create", repository_path)
+
+      import_path = File.join(dir, "import")
+      FileUtils.mkdir_p(import_path)
+      File.write(File.join(import_path, "a.txt"), "FILE: a.txt\n")
+      File.write(File.join(import_path, "b.txt"), "FILE: b.txt\n")
+
+      repository_url = "file://#{repository_path}"
+      run_command("svn", "import",
+                  import_path, "#{repository_url}/dir",
+                  "-m", "Add dir/{a.txt,b.txt}")
+      repository_url
+    end
+
+    def build_move_directory_repository(dir)
+      repository_url = create_test_repository(dir)
+      run_command("svn", "move",
+                  "#{repository_url}/dir", "#{repository_url}/renamed",
+                  "-m", "Move dir to renamed")
+      repository_url
+    end
+
+    def build_delete_directory_repository(dir)
+      repository_url = create_test_repository(dir)
+      run_command("svn", "rm",
+                  "#{repository_url}/dir",
+                  "-m", "Delete dir")
+      repository_url
+    end
   end
 end

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -125,8 +125,8 @@ module FullTextSearch
     def test_move_directory
       Dir.mktmpdir do |dir|
         repository_url = build_move_directory_repository(dir)
-        repository = Repository::Subversion.create(project: @project,
-                                                   url: repository_url)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
         repository.fetch_changesets
 
         move_changeset = repository.changesets.find_by!(revision: "2")


### PR DESCRIPTION
Related: GitHub GH-203

The path for `D` becomes a directory when it is deleted or moved.

* Deleted
  * Remove records in `fts_targets` that begin with `path/`.
* Moved
  * Even after the move, `Change` does not have records for each file in the directory.
  * We'll update and reuse the data from before the move that is already in `fts_targets`.
  * When moving data, the records in `fts_targets` are not deleted.

Updating the data after the move will be handled in a follow up PR for this directory move support.