### PR TITLE
test: remove `\r` from the expected value.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - redmine-version: "5.1"
-            ruby-version: "3.2"
-            rdbms: "MySQL"
-          - redmine-version: "5.1"
-            ruby-version: "3.2"
-            rdbms: "PostgreSQL"
           - redmine-version: "6.0"
             ruby-version: "3.2"
             rdbms: "MySQL"

--- a/test/functional/full_text_search/search_controller_test.rb
+++ b/test/functional/full_text_search/search_controller_test.rb
@@ -505,8 +505,8 @@ module FullTextSearch
             {
               title: @attachment.filename,
               description: <<-DESCRIPTION,
-this is a text file for <span class="keyword">upload</span> tests\r
-with multiple lines\r
+this is a text file for <span class="keyword">upload</span> tests
+with multiple lines
               DESCRIPTION
               rank: adjust_slice_score(2),
             }

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -16,7 +16,7 @@ module FullTextSearch
     def test_save
       filename = "testfile.txt"
       file = uploaded_test_file(filename, "text/plain")
-      content = "this is a text file for upload tests\r\nwith multiple lines\r\n"
+      content = "this is a text file for upload tests\nwith multiple lines\n"
       attachment = Attachment.generate!(file: file)
       attachment.reload
       issue = attachment.container


### PR DESCRIPTION
We use Redmine's fixtures, and it has been updated.
https://github.com/redmine/redmine/commit/ffffc4c4e33bf6f5bad88302f9a11dcdd0fed0d0

It has also been added to RedMica.
https://github.com/redmica/redmica/commit/c38c8c2e849518a0fd6e0fd7edeffada4c851e73

Redmine < 6.0 still contains `\r`, but since it's already EOL, we've dropped it from CI.
https://www.redmine.org/news/161