### PR TITLE
Support drilldown by assigned user

### DIFF
--- a/app/models/full_text_search/tag.rb
+++ b/app/models/full_text_search/tag.rb
@@ -60,6 +60,12 @@ module FullTextSearch
                           name: user_id.to_s)
       end
 
+      def user_group(group_id)
+        type = TagType.user_group
+        find_or_create_by(type_id: type.id,
+                          name: group_id.to_s)
+      end
+
       def label(label)
         type = TagType.label
         find_or_create_by(type_id: type.id,
@@ -80,6 +86,8 @@ module FullTextSearch
         Tracker.find(name.to_i)
       when TagType.user.id
         User.find(name.to_i)
+      when TagType.user_group.id
+        Group.find(name.to_i)
       else
         name
       end

--- a/app/models/full_text_search/tag_type.rb
+++ b/app/models/full_text_search/tag_type.rb
@@ -28,6 +28,10 @@ module FullTextSearch
         find_or_create_by(name: "user")
       end
 
+      def user_group
+        find_or_create_by(name: "group")
+      end
+
       def label
         find_or_create_by(name: "label")
       end

--- a/lib/full_text_search/issue_mapper.rb
+++ b/lib/full_text_search/issue_mapper.rb
@@ -26,6 +26,13 @@ module FullTextSearch
       fts_target.content = content_text
       tag_ids.concat(content_tag_ids)
       tag_ids << Tag.user(@record.author_id).id if @record.author_id
+      if @record.assigned_to_id
+        if @record.assigned_to.is_a?(Group)
+          tag_ids << Tag.user_group(@record.assigned_to_id).id
+        else
+          tag_ids << Tag.user(@record.assigned_to_id).id
+        end
+      end
       fts_target.is_private = @record.is_private
       tag_ids << Tag.issue_status(@record.status_id).id if @record.status_id
       fts_target.tag_ids = tag_ids

--- a/test/unit/full_text_search/issue_test.rb
+++ b/test/unit/full_text_search/issue_test.rb
@@ -44,6 +44,42 @@ module FullTextSearch
                    targets.collect {|target| target.attributes.except("id")})
     end
 
+    def test_save_assigned_to_user
+      user = User.find(3)
+      issue = Issue.generate!(:assigned_to => user)
+      targets = Target.where(source_id: issue.id,
+                             source_type_id: Type.issue.id)
+      assert_equal([
+                     [
+                       Tag.tracker(issue.tracker_id),
+                       Tag.user(issue.author_id),
+                       Tag.user(user.id),
+                       Tag.issue_status(issue.status_id),
+                     ].sort_by(&:id),
+                   ],
+                   targets.collect {|target| target.tags.sort_by(&:id)})
+    end
+
+    def test_save_assigned_to_group
+      group = Group.find(11)
+      issue = nil
+      with_settings(:issue_group_assignment => "1") do
+        issue = Issue.generate!(:project => Project.find(2),
+                                :assigned_to => group)
+      end
+      targets = Target.where(source_id: issue.id,
+                             source_type_id: Type.issue.id)
+      assert_equal([
+                     [
+                       Tag.tracker(issue.tracker_id),
+                       Tag.user(issue.author_id),
+                       Tag.user_group(group.id),
+                       Tag.issue_status(issue.status_id),
+                     ].sort_by(&:id),
+                   ],
+                   targets.collect {|target| target.tags.sort_by(&:id)})
+    end
+
     def test_save_journal_status_and_tracker
       issue = Issue.generate!(
         status: IssueStatus.find_by_name("New"),


### PR DESCRIPTION
Until now, only `author_id` was in `tag_ids`.
Add `assigned_to_id` to `tag_ids`.
This enables filtering search results by assignee in the drilldown.

But we can also specify a group for `assigned_to`. So, adding `group` to `tag_type`.