### PR TITLE
change_mapper: Delete fts_targets for files removed from a moved directory in the same commit

### DIFF
--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -214,10 +214,12 @@ module FullTextSearch
     end
 
     def upsert_fts_targets_for_moved_directory(repository, changeset)
-      each_entries(repository, @record.path, changeset.identifier) do |new_path|
-        relative_path = new_path.delete_prefix(@record.path)
-        from_full_path = @record.from_path + relative_path
-        upsert_fts_target_for_moved_file(repository, changeset, new_path, from_full_path)
+      # Since the file may have been deleted from the new path after being moved,
+      # we'll process it based on `from_path`.
+      each_entries(repository, @record.from_path, @record.from_revision) do |from_path|
+        relative_path = from_path.delete_prefix(@record.from_path)
+        new_path = @record.path + relative_path
+        upsert_fts_target_for_moved_file(repository, changeset, new_path, from_path)
       end
     end
 
@@ -239,6 +241,12 @@ module FullTextSearch
         end
       fts_target ||= find_old_fts_targets(path: from_path).first
       return unless fts_target
+
+      unless RepositoryEntry.new(repository, new_path, changeset.identifier).file?
+        # Since it was deleted from the directory after the move, delete it.
+        fts_target.destroy
+        return
+      end
 
       fts_target.title = "#{new_path}@#{changeset.identifier}"
       fts_target.container_id = repository.id

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -259,6 +259,43 @@ module FullTextSearch
       end
     end
 
+    def test_move_directory_with_deleted_file
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_with_deleted_file_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+        move_changeset = repository.changesets.find_by!(revision: "2")
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        original_b_change = Change.find_by!(path: "/dir/b.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        b_target = Target.find_by(source_id: original_b_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal([
+          {
+            "project_id" => @project.id,
+            "source_id" => original_a_change.id,
+            "source_type_id" => Type.change.id,
+            "last_modified_at" => move_changeset.committed_on,
+            "registered_at" => move_changeset.committed_on,
+            "container_id" => repository.id,
+            "container_type_id" => Type.repository.id,
+            "title" => "/renamed/a.txt@2",
+            "content" => "FILE: a.txt\n",
+            "custom_field_id" => null_number,
+            "is_private" => null_boolean,
+            "tag_ids" => [Tag.extension("txt").id],
+          },
+          nil,
+        ],
+        [
+          a_target.attributes.except("id"),
+          b_target,
+        ])
+      end
+    end
+
     private
     def run_command(*args)
       assert(system(*args), "Command failed: #{args.join(' ')}")
@@ -309,6 +346,21 @@ module FullTextSearch
       run_command("svn", "copy",
                   "#{repository_url}/dir", "#{repository_url}/copied",
                   "-m", "Copy dir to copied")
+      repository_url
+    end
+
+    def build_move_directory_with_deleted_file_repository(dir)
+      repository_url = create_test_repository(dir)
+      # Checkout to perform both `move` and `rm` in the same commit.
+      # (Operations on `repository_url` result in a separate commit for each operation.)
+      work_path = File.join(dir, "work")
+      run_command("svn", "checkout", repository_url, work_path)
+      run_command("svn", "move",
+                  File.join(work_path, "dir"), File.join(work_path, "renamed"))
+      run_command("svn", "rm", File.join(work_path, "renamed", "b.txt"))
+      run_command("svn", "commit",
+                  "-m", "Move dir to renamed and remove b.txt",
+                  work_path)
       repository_url
     end
   end


### PR DESCRIPTION
If a file under a moved directory is deleted in the same commit as the move, its `fts_targets` row was left behind.
For example, given the following commit:

```
D /work/dir
A /work/renamed
D /work/renamed/b.txt
```

While processing `D /work/renamed/b.txt`, we look up the row by its new path.
But the row is still titled with the old path `/work/dir/b.txt`.
The move handling for `A /work/renamed` retitles files by listing the new directory's entries as of the commit.
That listing no longer includes a file deleted in the same commit, so the file is never retitled.
As a result, the lookup by the new path fails, and the stale row remains in `fts_targets`.

To fix this, we now list entries from the old directory as of `from_revision` instead of the new directory.
So files deleted in the same commit are still processed. For each of them, if it no longer exists at the new path, we delete its `fts_targets` row instead of retitling it.