### PR TITLE
Include private issues in the search results

### DIFF
--- a/app/models/full_text_search/request.rb
+++ b/app/models/full_text_search/request.rb
@@ -170,6 +170,19 @@ module FullTextSearch
       viewable_projects.pluck(:id)
     end
 
+    def all_private_issues_visible_project_ids
+      return [] unless user.logged?
+      # For administrators, all projects are targeted.
+      condition = Project.allowed_to_condition(user, :view_issues) do |role|
+        if role.issues_visibility == "all"
+          "1=1"
+        else
+          "1=0"
+        end
+      end
+      Project.where(condition).pluck(:id)
+    end
+
     def tag_drilldown?(tag_type_id)
       each_tag.any? do |tag|
         tag.type_id == tag_type_id

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -126,6 +126,38 @@ module FullTextSearch
       "(#{conditions.join(operator)})"
     end
 
+    def private_issue_bypass_condition
+      user = @request.user
+      # Only logged-in users can view private issues.
+      return nil unless user.logged?
+      # Only relevant when issues are part of the search target.
+      return nil unless @request.target_search_types.include?("issues")
+
+      sub_conditions = []
+      # In a project, users with the `issues_visibility == "all"` role
+      # can view private issues in that project.
+      project_ids = @request.all_private_issues_visible_project_ids
+      unless project_ids.empty?
+        sub_conditions << "in_values(project_id, #{project_ids.join(', ')})"
+      end
+
+      # The author and the assignee can view private issues.
+      tag_ids = [Tag.user(user.id).id]
+      tag_ids += user.groups.pluck(:id).collect do |group_id|
+        Tag.user_group(group_id).id
+      end
+      if Target.highlight_keyword_extraction_is_broken?
+        sub_conditions << "query('tag_ids', '#{tag_ids.join(' ')}')"
+      else
+        tag_ids.each do |tag_id|
+          sub_conditions << "tag_ids @ #{tag_id}"
+        end
+      end
+
+      "source_type_id == #{Type.issue.id} && " +
+        "(#{sub_conditions.join(' || ')})"
+    end
+
     def filter
       project_ids = @request.target_project_ids
       return nil if project_ids.empty?
@@ -169,7 +201,12 @@ module FullTextSearch
       # TODO: Support private notes again
       # Project.allowed_to(user, :view_private_notes).pluck(:id)
       conditions << "&!"
-      conditions << "is_private == true"
+      bypass_condition = private_issue_bypass_condition
+      if bypass_condition
+        conditions << "(is_private == true && !(#{bypass_condition}))"
+      else
+        conditions << "is_private == true"
+      end
 
       unless @request.attachments?
         conditions << "&!"

--- a/lib/full_text_search/searcher.rb
+++ b/lib/full_text_search/searcher.rb
@@ -137,7 +137,7 @@ module FullTextSearch
       # In a project, users with the `issues_visibility == "all"` role
       # can view private issues in that project.
       project_ids = @request.all_private_issues_visible_project_ids
-      unless project_ids.empty?
+      if project_ids.present?
         sub_conditions << "in_values(project_id, #{project_ids.join(', ')})"
       end
 

--- a/test/system/full_text_search/search_test.rb
+++ b/test/system/full_text_search/search_test.rb
@@ -77,7 +77,7 @@ module FullTextSearch
                     id: subproject1.identifier))
       click_on("search-target-issues")
       within("#search-results") do
-        assert_equal(2, all("li").size)
+        assert_equal(3, all("li").size)
       end
       within(".pagination") do
         assert_equal([], all("li").to_a)

--- a/test/unit/full_text_search/searcher_test.rb
+++ b/test/unit/full_text_search/searcher_test.rb
@@ -45,6 +45,14 @@ module FullTextSearch
       Searcher.new(request).search
     end
 
+    def generate_private_issue(attributes={})
+      Issue.generate!({
+                        project: @project,
+                        subject: "FTS: PRIVATE ISSUE",
+                        is_private: true,
+                      }.merge(attributes))
+    end
+
     def test_open_issues
       parameters = {
         issues: "1",
@@ -181,6 +189,93 @@ module FullTextSearch
       searched_issues = targets.collect(&:source_record)
       ordered_issues = [issue_with_low_score, issue_with_middle_score, issue_with_high_score]
       assert_equal(ordered_issues, searched_issues)
+    end
+
+    def test_private_issue_invisible
+      issue = generate_private_issue(author: User.find(2))
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_not_include(issue.subject,
+                         search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_invisible_by_anonymous_user
+      # Anonymous users cannot view issues they created themselves.
+      @user = User.anonymous
+      issue = generate_private_issue(author: @user)
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_not_include(issue.subject,
+                         search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_visible_by_author
+      issue = generate_private_issue(author: @user)
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_include(issue.subject,
+                     search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_visible_by_assigned_user
+      # An assignee must be a member of the project.
+      # Since `@user = User.find(4)` is not a member, use `User.find(3)` instead.
+      @user = User.find(3)
+      issue = generate_private_issue(author: User.find(2),
+                                     assigned_to: @user)
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_include(issue.subject,
+                     search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_visible_by_assigned_group
+      # User.find(8) belongs to Group.find(11) and Group.find(11) is a member
+      # of Project.find(2).
+      @project = Project.find(2)
+      @user = User.find(8)
+      issue = nil
+      with_settings(:issue_group_assignment => "1") do
+        issue = generate_private_issue(author: User.find(2),
+                                       assigned_to: Group.find(11))
+      end
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_include(issue.subject,
+                     search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_visible_by_all_issues_visibility_role
+      # Use `User.find(2)`, as `role.issues_visibility == "all"`.
+      @user = User.find(2)
+      issue = generate_private_issue(author: User.find(3))
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_include(issue.subject,
+                     search(parameters).records.collect(&:title))
+    end
+
+    def test_private_issue_visible_by_admin
+      @user = User.find(1)
+      issue = generate_private_issue(author: User.find(3))
+      parameters = {
+        issues: "1",
+        limit: "-1",
+      }
+      assert_include(issue.subject,
+                     search(parameters).records.collect(&:title))
     end
   end
 end


### PR DESCRIPTION
The search results are personalized for each user.

A private issue is included in the results when:

* the user is its author
* the user is its assignee
* the user has a role with `issues_visibility == "all"` in its project
* the user is an administrator

The attachments and the custom values of a private issue are still invisible.
We'll support them in another pull request.

Private notes are also still invisible.
We'll support them in another pull request, too.