### PR TITLE
synchronize: keep fts_targets for files under a moved directory

### DIFF
--- a/lib/full_text_search/batch_runner.rb
+++ b/lib/full_text_search/batch_runner.rb
@@ -210,7 +210,7 @@ module FullTextSearch
                        },
                        path: entry.path)
           unless change
-            # In some cases, `change.path` and `fts_targets.title` do not match.
+            # In some cases, there is no `Change` whose `path` matches `entry.path`.
             # For details, see `change_mapper.rb`.
             # Therefore, we check if the data matching `entry.path` exists in `fts_targets`.
             existing_target =

--- a/lib/full_text_search/batch_runner.rb
+++ b/lib/full_text_search/batch_runner.rb
@@ -209,7 +209,18 @@ module FullTextSearch
                          revision: entry_identifier,
                        },
                        path: entry.path)
-          next unless change
+          unless change
+            # In some cases, `change.path` and `fts_targets.title` do not match.
+            # For details, see `change_mapper.rb`.
+            # Therefore, we check if the data matching `entry.path` exists in `fts_targets`.
+            existing_target =
+              RedmineChangeMapper
+                .find_fts_targets_by_path(repository, entry.path)
+                .first
+            existing_target_ids.delete(existing_target.source_id) if existing_target
+            next
+          end
+
           existing_target_ids.delete(change.id)
           if options.upsert == :later
             UpsertTargetJob

--- a/lib/full_text_search/batch_runner.rb
+++ b/lib/full_text_search/batch_runner.rb
@@ -216,7 +216,8 @@ module FullTextSearch
             existing_target =
               RedmineChangeMapper
                 .find_fts_targets_by_path(repository, entry.path)
-                .first
+                .order(:last_modified_at)
+                .last
             existing_target_ids.delete(existing_target.source_id) if existing_target
             next
           end

--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -27,6 +27,32 @@ module FullTextSearch
         super.where(action: ["A", "M", "R"],
                     id: source_ids)
       end
+
+      def find_fts_targets_by_path(repository, path, descendants: false)
+        escaped_path = Target.sanitize_sql_like(path)
+        # Exclude `@%@%` so that `file.txt@<revision>` doesn't match `file.txt@2026`
+        # when both `file.txt` and `file.txt@2026` exist.
+        condition = "title LIKE ? AND title NOT LIKE ?"
+        values = ["#{escaped_path}@%", "#{escaped_path}@%@%"]
+        if descendants
+          # Also match descendants, to support cases where `path` is a directory.
+          condition = "(#{condition}) OR title LIKE ?"
+          values << "#{escaped_path}/%"
+        end
+
+        Target
+          .joins(<<-JOIN)
+JOIN changes
+  ON source_type_id = #{Type.change.id} AND
+     source_id = changes.id
+JOIN changesets
+  ON changes.changeset_id = changesets.id
+JOIN repositories
+  ON changesets.repository_id = repositories.id
+          JOIN
+          .where(repositories: {id: repository.id})
+          .where(condition, *values)
+      end
     end
 
     def upsert_fts_target(options={})
@@ -164,29 +190,9 @@ module FullTextSearch
     end
 
     def find_fts_targets(path: nil, descendants: false)
-      escaped_path = Target.sanitize_sql_like(path || @record.path)
-      # Exclude `@%@%` so that `file.txt@<revision>` doesn't match `file.txt@2026`
-      # when both `file.txt` and `file.txt@2026` exist.
-      condition = "title LIKE ? AND title NOT LIKE ?"
-      values = ["#{escaped_path}@%", "#{escaped_path}@%@%"]
-      if descendants
-        # Also match descendants, to support cases where `path` is a directory.
-        condition = "(#{condition}) OR title LIKE ?"
-        values << "#{escaped_path}/%"
-      end
-
-      Target
-        .joins(<<-JOIN)
-  JOIN changes
-    ON source_type_id = #{Type.change.id} AND
-       source_id = changes.id
-  JOIN changesets
-    ON changes.changeset_id = changesets.id
-  JOIN repositories
-    ON changesets.repository_id = repositories.id
-        JOIN
-        .where(repositories: {id: @record.changeset.repository.id})
-        .where(condition, *values)
+      self.class.find_fts_targets_by_path(@record.changeset.repository,
+                                          path || @record.path,
+                                          descendants: descendants)
     end
 
     def find_old_fts_targets(path: nil, descendants: false)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -198,3 +198,9 @@ class RepositoryInfo
     files
   end
 end
+
+module CommandRunner
+  def run_command(*args)
+    assert(system(*args), "Command failed: #{args.join(' ')}")
+  end
+end

--- a/test/unit/full_text_search/batch_runner_synchronize_test.rb
+++ b/test/unit/full_text_search/batch_runner_synchronize_test.rb
@@ -85,7 +85,8 @@ module FullTextSearch
 
         a_target = Target.find_by(title: "/renamed/a.txt@2")
         b_target = Target.find_by(title: "/renamed/b.txt@2")
-
+        assert_not_nil(a_target, "Expected /renamed/a.txt@2 to be indexed")
+        assert_not_nil(b_target, "Expected /renamed/b.txt@2 to be indexed")
         runner = BatchRunner.new
         assert_no_difference("Target.count") do
           runner.synchronize_repositories(project: project)

--- a/test/unit/full_text_search/batch_runner_synchronize_test.rb
+++ b/test/unit/full_text_search/batch_runner_synchronize_test.rb
@@ -2,6 +2,7 @@ require File.expand_path("../../../test_helper", __FILE__)
 
 module FullTextSearch
   class BatchRunnerSynchronizeTest < ActiveSupport::TestCase
+    include CommandRunner
     include PrettyInspectable
 
     fixtures :attachments
@@ -71,6 +72,29 @@ module FullTextSearch
       # Including only the latest files at the default branch.
       assert_difference("Target.count", repository_info.files.size) do
         runner.synchronize_repositories(project: project)
+      end
+    end
+
+    def test_subversion_repository_moved_directory
+      project = Project.find(3)
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_repository(dir)
+        repository = Repository::Subversion.create(:project => project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        a_target = Target.find_by(title: "/renamed/a.txt@2")
+        b_target = Target.find_by(title: "/renamed/b.txt@2")
+
+        runner = BatchRunner.new
+        assert_no_difference("Target.count") do
+          runner.synchronize_repositories(project: project)
+        end
+        assert_equal([a_target.id, b_target.id],
+                     [
+                       Target.find_by(title: "/renamed/a.txt@2").id,
+                       Target.find_by(title: "/renamed/b.txt@2").id,
+                     ])
       end
     end
 
@@ -322,6 +346,26 @@ module FullTextSearch
       not_archived_projects = Project.where.not(status: Project::STATUS_ARCHIVED)
       assert_equal([],
                    Target.pluck(:project_id) - not_archived_projects.pluck(:id))
+    end
+
+    private
+    def build_move_directory_repository(dir)
+      repository_path = File.join(dir, "repository")
+      run_command("svnadmin", "create", repository_path)
+
+      import_path = File.join(dir, "import")
+      FileUtils.mkdir_p(import_path)
+      File.write(File.join(import_path, "a.txt"), "FILE: a.txt\n")
+      File.write(File.join(import_path, "b.txt"), "FILE: b.txt\n")
+
+      repository_url = "file://#{repository_path}"
+      run_command("svn", "import",
+                  import_path, "#{repository_url}/dir",
+                  "-m", "Add dir/{a.txt,b.txt}")
+      run_command("svn", "move",
+                  "#{repository_url}/dir", "#{repository_url}/renamed",
+                  "-m", "Move dir to renamed")
+      repository_url
     end
   end
 end

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -2,8 +2,9 @@ require File.expand_path("../../../test_helper", __FILE__)
 
 module FullTextSearch
   class ChangeSubversionTest < ActiveSupport::TestCase
-    include PrettyInspectable
+    include CommandRunner
     include NullValues
+    include PrettyInspectable
     include TimeValue
 
     fixtures :enabled_modules
@@ -297,10 +298,6 @@ module FullTextSearch
     end
 
     private
-    def run_command(*args)
-      assert(system(*args), "Command failed: #{args.join(' ')}")
-    end
-
     def create_test_repository(dir)
       repository_path = File.join(dir, "repository")
       run_command("svnadmin", "create", repository_path)


### PR DESCRIPTION
If there is a mismatch between `change.path` and `fts_targets.title`, the target is deleted.
But in the following commit, there are cases that become mismatched even though the data itself is correct.
https://github.com/clear-code/redmine_full_text_search/commit/677ea4acf7cb76114b2d40db9f350b64bf8fd699

This fix supports that case.