### PR TITLE
change_mapper: remove `fts_target_keys`

### DIFF
--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -150,14 +150,6 @@ module FullTextSearch
         .exists?
     end
 
-    def fts_target_keys
-      {
-        source_id: @record.id,
-        source_type_id: Type[@record].id,
-        title: target_title,
-      }
-    end
-
     def directory_move_destination?
       change = Change
         .where(changeset_id: @record.changeset_id,


### PR DESCRIPTION
Since the `source_id` and `source_type_id` make the record unique, the `title` is not required. `RedmineMapper#fts_target_keys` is sufficient, so there is no need to override it.