### PR TITLE
reload: Replay directory moves in Subversion

### DIFF
--- a/lib/full_text_search/batch_runner.rb
+++ b/lib/full_text_search/batch_runner.rb
@@ -68,6 +68,23 @@ module FullTextSearch
         end
       end
       bar.finish
+
+      # If titles were updated with `move` operation, reloading `Change` will
+      # revert the titles to their previous values.
+      # Replay the `move` operation and update the `title`.
+      return unless options.type.blank? || options.type == Type.change
+      if options.upsert == :later
+        Rails.logger.warn("[full_text_search][reload] " +
+                          "Run `full_text_search:change:replay_directories` " +
+                          "once the queued jobs have finished.")
+      else
+        replay_change_directories_internal(options)
+      end
+    end
+
+    def replay_change_directories(project: nil)
+      options = Options.new(project)
+      replay_change_directories_internal(options)
     end
 
     def extract_text(ids: nil)
@@ -277,6 +294,38 @@ module FullTextSearch
         bar.finish
       end
       all_bar.finish
+    end
+
+    def replay_change_directories_internal(options)
+      # Only Subversion records a change whose path is a directory. For the
+      # other SCMs a move is recorded per file, so there is nothing to replay.
+      # Since `action=D` is executed with synchronize, it is not targeted here.
+      changes =
+        Change
+          .joins(changeset: :repository)
+          .where(repositories: {type: Repository::Subversion.name})
+          .where(action: ["A", "R"])
+          .where.not(from_path: nil)
+      if options.project
+        changes =
+          changes
+            .joins(changeset: {repository: :project})
+            .where(projects: {id: options.project.id})
+      end
+
+      bar = create_progress_bar("FullTextSearch::Change",
+                                total: changes.count)
+      bar.start
+      # Since updates will not be applied correctly if not executed in the order
+      # of the commits, we perform synchronization.
+      #
+      # Redmine inserts `Change` in commit order.
+      # `find_each` processes the records in `id` order.
+      bar.iterate(changes.find_each) do |change|
+        mapper = ChangeMapper.redmine_mapper(change)
+        mapper.upsert_fts_target(replay: true)
+      end
+      bar.finish
     end
 
     def process_orphan_change_targets?(repository)

--- a/lib/full_text_search/change_mapper.rb
+++ b/lib/full_text_search/change_mapper.rb
@@ -67,11 +67,14 @@ JOIN repositories
                                     @record.path,
                                     changeset.identifier)
         if entry.directory?
-          if @record.action == "R"
+          if @record.action == "R" and not options[:replay]
             # `R dir` is used when executing commands such as `rm -rf dir; cp -R from dir`.
             # In this case, `D dir` is not inserted.
             # Also, as the command examples show, the old `dir` and the new `dir` are completely different.
             # Therefore, first delete the records in the old `dir`.
+            #
+            # If delete is executed in `replay`, it may delete files added after this commit.
+            # Therefore, `replay` does not perform the delete.
             find_old_fts_targets(descendants: true).destroy_all
           end
 
@@ -114,9 +117,11 @@ JOIN repositories
         fts_target.registered_at = changeset.committed_on
         fts_target.tag_ids = extract_tag_ids_from_path(@record.path)
         if fts_target.changed?
-          prepare_text_extraction(fts_target)
+          # Since the purpose of `replay` is to update the title when performing directory operations,
+          # it does not update the content.
+          prepare_text_extraction(fts_target) unless options[:replay]
           fts_target.save!
-          extract_content(fts_target, options)
+          extract_content(fts_target, options) unless options[:replay]
         end
       when "D"
         # For Subversion:
@@ -260,7 +265,12 @@ JOIN repositories
       fts_target.project_id = repository.project_id
       fts_target.last_modified_at = changeset.committed_on
       fts_target.registered_at = changeset.committed_on
-      fts_target.tag_ids = extract_tag_ids_from_path(new_path)
+      # Keep the text extraction tags. Otherwise a move that happens while
+      # the extraction is still pending would drop `text_extraction_yet`
+      # and the target would stay without its content forever.
+      fts_target.tag_ids =
+        extract_tag_ids_from_path(new_path) +
+        (fts_target.tag_ids & Tag.text_extraction_ids)
 
       # Since the file's content should be the same, we don't re-fetch it
       fts_target.save!

--- a/lib/tasks/full_text_search.rake
+++ b/lib/tasks/full_text_search.rake
@@ -77,6 +77,14 @@ namespace :full_text_search do
     end
   end
 
+  namespace :change do
+    desc "Rename targets for files under directories moved in Subversion. Run this before repository:synchronize"
+    task :replay_directories => :environment do
+      batch_runner = FullTextSearch::BatchRunner.new(show_progress: true)
+      batch_runner.replay_change_directories(project: ENV["PROJECT"])
+    end
+  end
+
   namespace :text do
     desc "Extract texts"
     task :extract => :environment do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -232,7 +232,7 @@ module SubversionRepositoryBuilder
     repository_url
   end
 
-  def build_2move_directory_repository(dir)
+  def build_move_directory_twice_repository(dir)
     repository_url = build_move_directory_repository(dir)
     run_command("svn", "move",
                 "#{repository_url}/renamed", "#{repository_url}/rerenamed",

--- a/test/unit/full_text_search/batch_runner_reload_test.rb
+++ b/test/unit/full_text_search/batch_runner_reload_test.rb
@@ -1,0 +1,118 @@
+require File.expand_path("../../../test_helper", __FILE__)
+
+module FullTextSearch
+  class BatchRunnerReloadTest < ActiveSupport::TestCase
+    include SubversionRepositoryBuilder
+
+    fixtures :enabled_modules
+    fixtures :projects
+    fixtures :repositories
+    fixtures :users
+    fixtures :roles
+
+    def setup
+      Target.destroy_all
+      @project = Project.find(3)
+    end
+
+    def test_reload_moved_directory
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal("/renamed/a.txt@2", a_target.title)
+
+        runner = BatchRunner.new
+        assert_no_difference("Target.count") do
+          runner.reload_fts_targets(project: @project)
+        end
+
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal("/renamed/a.txt@2", a_target.title)
+      end
+    end
+
+    def test_reload_moved_directory_twice
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_twice_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal("/rerenamed/a.txt@3", a_target.title)
+
+        runner = BatchRunner.new
+        assert_no_difference("Target.count") do
+          runner.reload_fts_targets(project: @project)
+        end
+
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal("/rerenamed/a.txt@3", a_target.title)
+      end
+    end
+
+    def test_replay_change_directories_restores_title
+      Dir.mktmpdir do |dir|
+        repository_url = build_move_directory_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        original_a_change = Change.find_by!(path: "/dir/a.txt")
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+
+        # Update it to simulate the old revision.
+        a_target.update!(title: "/dir/a.txt@1")
+
+        runner = BatchRunner.new
+        assert_no_difference("Target.count") do
+          runner.replay_change_directories(project: @project)
+        end
+
+        a_target = Target.find_by(source_id: original_a_change.id,
+                                  source_type_id: Type.change.id)
+        assert_equal("/renamed/a.txt@2", a_target.title)
+      end
+    end
+
+    def test_replay_change_directories_keeps_replaced_directory
+      Dir.mktmpdir do |dir|
+        repository_url = build_replace_directory_with_move_repository(dir)
+        repository = Repository::Subversion.create(:project => @project,
+                                                   :url => repository_url)
+        repository.fetch_changesets
+
+        expected = Target
+          .where(source_type_id: Type.change.id,
+                 container_id: repository.id,
+                 container_type_id: Type.repository.id)
+          .order(:id)
+          .pluck(:title)
+
+        runner = BatchRunner.new
+        assert_no_difference("Target.count") do
+          runner.replay_change_directories(project: @project)
+        end
+
+        actual = Target
+          .where(source_type_id: Type.change.id,
+                 container_id: repository.id,
+                 container_type_id: Type.repository.id)
+          .order(:id)
+          .pluck(:title)
+        assert_equal(expected, actual)
+      end
+    end
+  end
+end

--- a/test/unit/full_text_search/change_subversion_test.rb
+++ b/test/unit/full_text_search/change_subversion_test.rb
@@ -174,9 +174,9 @@ module FullTextSearch
       end
     end
 
-    def test_2move_directory
+    def test_move_directory_twice
       Dir.mktmpdir do |dir|
-        repository_url = build_2move_directory_repository(dir)
+        repository_url = build_move_directory_twice_repository(dir)
         repository = Repository::Subversion.create(:project => @project,
                                                    :url => repository_url)
         repository.fetch_changesets


### PR DESCRIPTION
Related: GitHub GH-203

`target:reload` rebuilds each `fts_targets` from its own `Change`, so a file under a moved directory gets its title reverted to the path the file was originally added at.
Add `full_text_search:change:replay_directories`, which replays the Subversion directory moves in commit order and renames the targets to their current paths.