### PR TITLE
custom_value_mapper: add the author and the assignee tags to the custom values

### DIFF
--- a/lib/full_text_search/custom_value_mapper.rb
+++ b/lib/full_text_search/custom_value_mapper.rb
@@ -57,6 +57,7 @@ JOIN projects
       when "Issue"
         fts_target.project_id = customized.project_id
         fts_target.is_private = customized.is_private
+        fts_target.tag_ids = extract_tag_ids_from_issue(customized)
       when "Project"
         fts_target.project_id = customized.id
       else

--- a/lib/full_text_search/issue_mapper.rb
+++ b/lib/full_text_search/issue_mapper.rb
@@ -24,15 +24,8 @@ module FullTextSearch
       parser = MarkupParser.new(@record.project)
       content_text, content_tag_ids = parser.parse(@record, :description)
       fts_target.content = content_text
-      tag_ids.concat(content_tag_ids)
-      tag_ids << Tag.user(@record.author_id).id if @record.author_id
-      if @record.assigned_to_id
-        if @record.assigned_to.is_a?(Group)
-          tag_ids << Tag.user_group(@record.assigned_to_id).id
-        else
-          tag_ids << Tag.user(@record.assigned_to_id).id
-        end
-      end
+      tag_ids.concat(content_tag_ids,
+                     extract_tag_ids_from_issue(@record))
       fts_target.is_private = @record.is_private
       tag_ids << Tag.issue_status(@record.status_id).id if @record.status_id
       fts_target.tag_ids = tag_ids
@@ -57,7 +50,11 @@ module FullTextSearch
         next unless redmine_mapper.find_fts_target.persisted?
         redmine_mapper.upsert_fts_target(options)
       end
-      # @record.custom_values
+      @record.custom_values.each do |custom_value|
+        redmine_mapper = CustomValueMapper.redmine_mapper(custom_value)
+        next unless redmine_mapper.find_fts_target.persisted?
+        redmine_mapper.upsert_fts_target(options)
+      end
     end
   end
 

--- a/lib/full_text_search/mapper.rb
+++ b/lib/full_text_search/mapper.rb
@@ -128,6 +128,19 @@ module FullTextSearch
       [Tag.extension(extension).id]
     end
 
+    def extract_tag_ids_from_issue(issue)
+      tag_ids = []
+      tag_ids << Tag.user(issue.author_id).id if issue.author_id
+      if issue.assigned_to_id
+        if issue.assigned_to.is_a?(Group)
+          tag_ids << Tag.user_group(issue.assigned_to_id).id
+        else
+          tag_ids << Tag.user(issue.assigned_to_id).id
+        end
+      end
+      tag_ids
+    end
+
     def extract_content(fts_target, options)
       case options[:extract_text] || :immediate
       when :immediate

--- a/test/unit/full_text_search/custom_value_test.rb
+++ b/test/unit/full_text_search/custom_value_test.rb
@@ -33,10 +33,30 @@ module FullTextSearch
                        "custom_field_id" => custom_field.id,
                        "container_id" => issue.id,
                        "container_type_id" => Type.issue.id,
-                       "tag_ids" => null_number_array,
+                       "tag_ids" => [
+                         Tag.user(issue.author_id).id,
+                       ],
                      },
                    ],
                    targets.collect {|target| target.attributes.except("id")})
+    end
+
+    def test_update_issue
+      issue = Issue.find(1)
+      custom_field = IssueCustomField.generate!(searchable: true)
+      custom_value = custom_field.custom_values.create!(value: "Hello",
+                                                        customized: issue)
+      issue.assigned_to = User.find(3)
+      issue.save!
+      targets = Target.where(source_id: custom_value.id,
+                             source_type_id: Type.custom_value.id)
+      assert_equal([
+                     [
+                       Tag.user(issue.author_id),
+                       Tag.user(issue.assigned_to_id),
+                     ].sort_by(&:id),
+                   ],
+                   targets.collect {|target| target.tags.sort_by(&:id)})
     end
 
     def test_save_project


### PR DESCRIPTION
This enables filtering by them in the drilldown.

`fts_targets` record of a custom value uses the values of its issue, so we update it when the issue is updated.