### PR TITLE
attachment_mapper: add the author and the assignee tags to the attachments

### DIFF
--- a/lib/full_text_search/attachment_mapper.rb
+++ b/lib/full_text_search/attachment_mapper.rb
@@ -60,7 +60,7 @@ JOIN projects
       fts_target.source_id = @record.id
       fts_target.source_type_id = Type[@record.class].id
       fts_target.title = @record.filename
-      fts_target.content = @record.description
+      fts_target.content = @record.description unless options[:skip_extract_content]
       fts_target.last_modified_at = @record.created_on
       fts_target.registered_at = @record.created_on
       tag_ids = []
@@ -71,6 +71,7 @@ JOIN projects
         fts_target.project_id = issue.project_id
         fts_target.is_private = issue.is_private
         tag_ids << Tag.issue_status(issue.status_id).id
+        tag_ids.concat(extract_tag_ids_from_issue(issue))
       when "Message"
         fts_target.project_id = @record.container.board.project_id
       when "Project"
@@ -85,10 +86,15 @@ JOIN projects
       fts_target.container_id = @record.container_id
       fts_target.container_type_id = Type[@record.container_type].id
       tag_ids.concat(extract_tag_ids_from_path(@record.filename))
+      if options[:skip_extract_content]
+        # Keep the tags for the status of the text extraction
+        # because we don't extract the text here.
+        tag_ids.concat((fts_target.tag_ids || []) & Tag.text_extraction_ids)
+      end
       fts_target.tag_ids = tag_ids
-      prepare_text_extraction(fts_target)
+      prepare_text_extraction(fts_target) unless options[:skip_extract_content]
       fts_target.save!
-      extract_content(fts_target, options)
+      extract_content(fts_target, options) unless options[:skip_extract_content]
     end
 
     def extract_text

--- a/lib/full_text_search/issue_mapper.rb
+++ b/lib/full_text_search/issue_mapper.rb
@@ -50,6 +50,14 @@ module FullTextSearch
         next unless redmine_mapper.find_fts_target.persisted?
         redmine_mapper.upsert_fts_target(options)
       end
+      @record.attachments.each do |attachment|
+        redmine_mapper = AttachmentMapper.redmine_mapper(attachment)
+        next unless redmine_mapper.find_fts_target.persisted?
+        # The attachment itself isn't changed here.
+        # Extracting its text again is expensive, so we keep the extracted
+        # content.
+        redmine_mapper.upsert_fts_target(options.merge(skip_extract_content: true))
+      end
       @record.custom_values.each do |custom_value|
         redmine_mapper = CustomValueMapper.redmine_mapper(custom_value)
         next unless redmine_mapper.find_fts_target.persisted?

--- a/test/unit/full_text_search/attachment_test.rb
+++ b/test/unit/full_text_search/attachment_test.rb
@@ -40,11 +40,37 @@ module FullTextSearch
                        "custom_field_id" => null_number,
                        "tag_ids" => [
                          Tag.issue_status(issue.status_id).id,
+                         Tag.user(issue.author_id).id,
                          Tag.extension("txt").id,
                        ],
                      }
                    ],
                    targets.collect {|target| target.attributes.except("id")})
+    end
+
+    def test_update_issue
+      file = uploaded_test_file("testfile.txt", "text/plain")
+      content = "this is a text file for upload tests\nwith multiple lines\n"
+      attachment = Attachment.generate!(file: file)
+      attachment.reload
+
+      issue = attachment.container
+      issue.assigned_to = User.find(3)
+      issue.save!
+
+      targets = Target.where(source_id: attachment.id,
+                             source_type_id: Type.attachment.id)
+      assert_equal([
+                     [
+                       Tag.issue_status(issue.status_id),
+                       Tag.user(issue.author_id),
+                       Tag.user(issue.assigned_to_id),
+                       Tag.extension("txt"),
+                     ].sort_by(&:id),
+                   ],
+                   targets.collect {|target| target.tags.sort_by(&:id)})
+      assert_equal([content],
+                   targets.collect {|target| target.content})
     end
 
     def test_destroy


### PR DESCRIPTION
This enables filtering by them in the drilldown.
The `fts_targets` record of an attachment uses the values of its issue, so we update it when the issue is updated.