### PR TITLE
test: Ignore the stdout of `run_command`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,7 +201,8 @@ end
 
 module CommandRunner
   def run_command(*args)
-    assert(system(*args), "Command failed: #{args.join(' ')}")
+    assert(system(*args, out: File::NULL),
+           "Command failed: #{args.join(' ')}")
   end
 end
 


### PR DESCRIPTION
The output from `system` is sent to stdout, making the test results hard to read.
Since we are not using stdout, we ignore it.